### PR TITLE
fix: re-align post categories to consistent 2-level hierarchy

### DIFF
--- a/_posts/2024-09-22-My-HomeLabs-Is-Crash-TH.md
+++ b/_posts/2024-09-22-My-HomeLabs-Is-Crash-TH.md
@@ -2,7 +2,7 @@
 title: เมื่อ Home Lab เกิดปัญหา (Proxmox)
 author: DevilDogTG
 date: 2024-08-11 08:00:00 +0700
-categories: [Blogs, Home Lab]
+categories: [Home Lab, General]
 tags: [blogs, homelab, proxmox, lang:th] # TAG names should always be lowercase
 ---
 

--- a/_posts/2025-09-18-linux-post-install-TH.md
+++ b/_posts/2025-09-18-linux-post-install-TH.md
@@ -2,7 +2,7 @@
 title: ตั้งค่าเพิ่มเติมหลังติดตั้ง Debian
 author: DevilDogTG
 date: 2025-09-18 10:09:00 +0700
-categories: [Linux, Configuration]
+categories: [System Administrator, Linux]
 tags: [tutorials, linux, debian, lang:th] # TAG names should always be lowercase
 ---
 

--- a/_posts/2025-09-22-windows-recovery-partition.md
+++ b/_posts/2025-09-22-windows-recovery-partition.md
@@ -2,7 +2,7 @@
 title: "Remove/Recreate Windows recovery partition"
 author: DevilDogTG
 date: 2025-09-22 08:44:00 +0700
-categories: [Windows, Configuration]
+categories: [System Administrator, Windows]
 tags: [tutorials, windows, partitions]
 ---
 

--- a/_posts/2025-10-24-extend-linux-lvm.md
+++ b/_posts/2025-10-24-extend-linux-lvm.md
@@ -2,7 +2,7 @@
 title: "How to extend LVM in Linux"
 author: DevilDogTG
 date: 2025-10-24 11:27:00 +0700
-categories: [Linux, Configuration]
+categories: [System Administrator, Linux]
 tags: [tutorials, linux, lvm, lang:en]
 ---
 


### PR DESCRIPTION
## Problem
Category names were overlapping between levels, causing the categories page to look misaligned:
- \Linux\ appeared as both a top-level category AND a sub-category under \System Administrator\
- \Windows\ appeared as both a top-level category AND a sub-category under \System Administrator\
- \Home Lab\ appeared as both a top-level category AND a sub-category under \Blogs\

## Changes (4 posts)
| File | Before | After |
|---|---|---|
| \2025-09-18-linux-post-install-TH.md\ | \[Linux, Configuration]\ | \[System Administrator, Linux]\ |
| \2025-10-24-extend-linux-lvm.md\ | \[Linux, Configuration]\ | \[System Administrator, Linux]\ |
| \2025-09-22-windows-recovery-partition.md\ | \[Windows, Configuration]\ | \[System Administrator, Windows]\ |
| \2024-09-22-My-HomeLabs-Is-Crash-TH.md\ | \[Blogs, Home Lab]\ | \[Home Lab, General]\ |

## Result — 4 clean top-level categories
- **Blogs** → Car, Games
- **Developers** → .NET, Git, Testing
- **Home Lab** → General, Kubernetes, Proxmox
- **System Administrator** → Certificates, Linux, Windows

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>