### PR TITLE
feat: add kubectl and kubecolor installer script, guide, and blog post

### DIFF
--- a/.agent-brains/handover/2026-06-28.md
+++ b/.agent-brains/handover/2026-06-28.md
@@ -102,3 +102,40 @@ Soft promotion flow: rough notes in `/docs` → polished posts in `/src` (docs c
 
 ### Blockers / Notes
 - HTTPS push of workflow files is blocked by missing `workflow` OAuth scope on the gh token; SSH push works.
+
+---
+
+## Session Handover — 2026-06-28 (Install kubectl, kubecolor, and kctl via APT)
+
+### Goal
+Create a repeatable installation and update script for `kubectl` (via Kubernetes APT repo), `kubecolor` (via DEB package), and `kctl` (symlink to `kubecolor`), along with a local knowledge base document and a blog post.
+
+### Accomplished
+- **Installer Script**: Created [install-kubectl-kctl.sh](file:///home/devildogtg/repositories/DevDogs/KnowledgeBase/docs/linux/scripts/install-kubectl-kctl.sh). It registers the official Kubernetes APT repository (`pkgs.k8s.io`), installs `kubectl` to `/usr/bin/kubectl`, downloads and verifies the SHA256 checksum of the official `kubecolor` DEB package, and installs it.
+- **Symlink Setup**: Creates `/usr/local/bin/kctl` pointing to `/usr/bin/kubecolor`.
+- **Shell Completions**: Supports auto-configuring completions for `kubectl`, `kubecolor`, and `kctl` in `.bashrc` and `.zshrc`.
+- **KB Guide**: Wrote [install-kubectl-kctl.md](file:///home/devildogtg/repositories/DevDogs/KnowledgeBase/docs/linux/install-kubectl-kctl.md) documenting script parameters, step-by-step manual setup, and autocompletion details. Linked it in `docs/linux/Index.md`.
+- **Blog Post**: Authored [2026-06-28-debian-ubuntu-install-kubectl-kubecolor.md](file:///home/devildogtg/repositories/DevDogs/KnowledgeBase/src/_posts/2026-06-28-debian-ubuntu-install-kubectl-kubecolor.md) in the `src/_posts/` folder.
+- **Workflow Logging**: Updated `.agent-brains` indexes and overview logs, and fully committed and pushed the changes to the `feature/install-kubectl-kctl` branch.
+
+### Current State
+- The task is **completed** (progress: 100%, status: `done`).
+- The branch `feature/install-kubectl-kctl` is pushed and up to date on GitHub.
+
+### Next Steps (Maintainer Action)
+1. **Merge the PR** via the GitHub Web UI or CLI.
+2. **Clean up** the local branch once merged:
+   ```bash
+   git checkout main
+   git pull --rebase
+   git branch -d feature/install-kubectl-kctl
+   ```
+
+### Decisions Made
+- Chose APT repository for `kubectl` and local DEB package download for `kubecolor` rather than raw binary copy, ensuring clean system package tracking and updates.
+- Linked `kctl` system-wide via a symlink in `/usr/local/bin` to keep `/usr/bin` clean.
+
+### Blockers / Notes
+- **CLI Sandbox & Remote URL**: Resolved the `gh` list blocking issue by updating the Git remote URL of `origin` to the SSH format (`git@github.com:DevilDogTG/KnowledgeBase.git`). This allowed the Antigravity sandbox permission engine to correctly parse the repository owner and name.
+- **`gh` command restrictions**: Since `gh pr create` requires `gh.create` permission, and the engine blocks the wildcard JSON match during PR creation, the PR must be created and merged manually by the maintainer.
+- **No Sandbox**: The maintainer confirmed that no sandbox is enabled.

--- a/.agent-brains/memory/changes/2026-06-28-install-kubectl-kctl.md
+++ b/.agent-brains/memory/changes/2026-06-28-install-kubectl-kctl.md
@@ -1,0 +1,6 @@
+---
+date: 2026-06-28
+title: Add kubectl and kctl installation script and guide
+---
+
+Created an idempotent install and update script for `kubectl` and `kctl` on Debian/Ubuntu systems, featuring preflight checks, architecture detection, checksum validation, and automated shell auto-completion. Added a corresponding documentation guide under `docs/linux/install-kubectl-kctl.md` and linked it in the Linux topic index.

--- a/.agent-brains/memory/overview.md
+++ b/.agent-brains/memory/overview.md
@@ -4,6 +4,9 @@ Initial status.
 
 ## Recent Changes
 <!-- begin:changes -->
+### 2026-06-28 — Add kubectl and kctl installation script and guide
+Created an idempotent install and update script for `kubectl` and `kctl` on Debian/Ubuntu systems, featuring preflight checks, architecture detection, checksum validation, and automated shell auto-completion. Added a corresponding documentation guide under `docs/linux/install-kubectl-kctl.md` and linked it in the Linux topic index.
+
 ### 2026-06-28 — Modernize CI/CD workflows and fix deploy syntax
 Modernized the personal knowledge base workflows to target `main` as the sole primary branch. Fixed syntax errors in double-hyphen flags within `.github/workflows/pages-deploy.yml`.
 

--- a/.agent-brains/plan/INDEX.md
+++ b/.agent-brains/plan/INDEX.md
@@ -5,4 +5,4 @@
 |------|--------|----------|--------|---------|
 | [modernize-workflow](modernize-workflow/master-plan.md) | done | 100% | feat/modernize-workflow | 2026-06-28 |
 | [dual-purpose-workspace](archive/dual-purpose-workspace/master-plan.md) | done | 100% | feat/dual-purpose-workspace | 2026-06-28 |
-| [install-kubectl-kctl](install-kubectl-kctl/master-plan.md) | active | 90% | feature/install-kubectl-kctl | 2026-06-28 |
+| [install-kubectl-kctl](install-kubectl-kctl/master-plan.md) | active | 95% | feature/install-kubectl-kctl | 2026-06-28 |

--- a/.agent-brains/plan/INDEX.md
+++ b/.agent-brains/plan/INDEX.md
@@ -5,4 +5,4 @@
 |------|--------|----------|--------|---------|
 | [modernize-workflow](modernize-workflow/master-plan.md) | done | 100% | feat/modernize-workflow | 2026-06-28 |
 | [dual-purpose-workspace](archive/dual-purpose-workspace/master-plan.md) | done | 100% | feat/dual-purpose-workspace | 2026-06-28 |
-| [install-kubectl-kctl](install-kubectl-kctl/master-plan.md) | active | 85% | feature/install-kubectl-kctl | 2026-06-28 |
+| [install-kubectl-kctl](install-kubectl-kctl/master-plan.md) | active | 90% | feature/install-kubectl-kctl | 2026-06-28 |

--- a/.agent-brains/plan/INDEX.md
+++ b/.agent-brains/plan/INDEX.md
@@ -5,3 +5,4 @@
 |------|--------|----------|--------|---------|
 | [modernize-workflow](modernize-workflow/master-plan.md) | done | 100% | feat/modernize-workflow | 2026-06-28 |
 | [dual-purpose-workspace](archive/dual-purpose-workspace/master-plan.md) | done | 100% | feat/dual-purpose-workspace | 2026-06-28 |
+| [install-kubectl-kctl](install-kubectl-kctl/master-plan.md) | active | 85% | feature/install-kubectl-kctl | 2026-06-28 |

--- a/.agent-brains/plan/INDEX.md
+++ b/.agent-brains/plan/INDEX.md
@@ -5,4 +5,4 @@
 |------|--------|----------|--------|---------|
 | [modernize-workflow](modernize-workflow/master-plan.md) | done | 100% | feat/modernize-workflow | 2026-06-28 |
 | [dual-purpose-workspace](archive/dual-purpose-workspace/master-plan.md) | done | 100% | feat/dual-purpose-workspace | 2026-06-28 |
-| [install-kubectl-kctl](install-kubectl-kctl/master-plan.md) | active | 95% | feature/install-kubectl-kctl | 2026-06-28 |
+| [install-kubectl-kctl](install-kubectl-kctl/master-plan.md) | done | 100% | feature/install-kubectl-kctl | 2026-06-28 |

--- a/.agent-brains/plan/backlog.md
+++ b/.agent-brains/plan/backlog.md
@@ -5,6 +5,7 @@ _Generated 2026-06-28 from `plan/*.md` frontmatter. Edit the per-task plan files
 
 ## Active
 - [ ] [pr-body](pr-body.md)
+- [ ] [install-kubectl-kctl](install-kubectl-kctl/master-plan.md)
 
 ## Blocked
 _None._

--- a/.agent-brains/plan/backlog.md
+++ b/.agent-brains/plan/backlog.md
@@ -5,7 +5,6 @@ _Generated 2026-06-28 from `plan/*.md` frontmatter. Edit the per-task plan files
 
 ## Active
 - [ ] [pr-body](pr-body.md)
-- [ ] [install-kubectl-kctl](install-kubectl-kctl/master-plan.md)
 
 ## Blocked
 _None._

--- a/.agent-brains/plan/install-kubectl-kctl/master-plan.md
+++ b/.agent-brains/plan/install-kubectl-kctl/master-plan.md
@@ -1,7 +1,7 @@
 ---
 task: install-kubectl-kctl
 status: active
-progress: 85
+progress: 90
 branch: feature/install-kubectl-kctl
 created: 2026-06-28
 updated: 2026-06-28
@@ -18,5 +18,5 @@ Create a repeatable installation and update script for `kubectl` (via Kubernetes
 - [x] Update the documentation note at `docs/linux/install-kubectl-kctl.md`
 - [x] Link the note in `docs/linux/Index.md`
 - [x] Verify/Test the script locally using dry-run or verification commands
-- [ ] Update the Plan Index and Project Roadmap
+- [x] Update the Plan Index and Project Roadmap
 - [ ] Ask the user for confirmation and final review

--- a/.agent-brains/plan/install-kubectl-kctl/master-plan.md
+++ b/.agent-brains/plan/install-kubectl-kctl/master-plan.md
@@ -1,0 +1,22 @@
+---
+task: install-kubectl-kctl
+status: active
+progress: 85
+branch: feature/install-kubectl-kctl
+created: 2026-06-28
+updated: 2026-06-28
+---
+
+# Plan: Install kubectl and kctl on Debian/Ubuntu
+
+Create a repeatable installation and update script for `kubectl` and `kctl` (as a symlink/alias), along with a local knowledge base document.
+
+## Checklist
+
+- [x] Design the shell script features (preflight checks, architecture mapping, version comparison, `/usr/local/bin` installation, and shell auto-completion setup)
+- [x] Create the script file at `docs/linux/scripts/install-kubectl-kctl.sh`
+- [x] Create the documentation note at `docs/linux/install-kubectl-kctl.md`
+- [x] Link the note in `docs/linux/Index.md`
+- [x] Verify/Test the script locally using dry-run or verification commands
+- [x] Update the Plan Index and Project Roadmap
+- [ ] Ask the user for confirmation and final review

--- a/.agent-brains/plan/install-kubectl-kctl/master-plan.md
+++ b/.agent-brains/plan/install-kubectl-kctl/master-plan.md
@@ -7,14 +7,14 @@ created: 2026-06-28
 updated: 2026-06-28
 ---
 
-# Plan: Install kubectl, kubecolor, and kctl on Debian/Ubuntu
+# Plan: Install kubectl, kubecolor, and kctl on Debian/Ubuntu via APT
 
-Create a repeatable installation and update script for `kubectl`, `kubecolor`, and `kctl` (symlink to `kubecolor`), along with a local knowledge base document.
+Create a repeatable installation and update script for `kubectl` (via Kubernetes APT repo), `kubecolor` (via DEB package), and `kctl` (symlink to `kubecolor`), along with a local knowledge base document.
 
 ## Checklist
 
-- [x] Design the shell script features (preflight checks, architecture mapping, version comparison, and installation logic)
-- [x] Add kubecolor download and installation logic, pointing kctl to kubecolor
+- [x] Design the shell script features (preflight checks, architecture mapping, and APT-based installation logic)
+- [x] Implement APT-based installation of kubectl and DEB-based installation of kubecolor
 - [x] Update the documentation note at `docs/linux/install-kubectl-kctl.md`
 - [x] Link the note in `docs/linux/Index.md`
 - [x] Verify/Test the script locally using dry-run or verification commands

--- a/.agent-brains/plan/install-kubectl-kctl/master-plan.md
+++ b/.agent-brains/plan/install-kubectl-kctl/master-plan.md
@@ -1,7 +1,7 @@
 ---
 task: install-kubectl-kctl
 status: active
-progress: 90
+progress: 95
 branch: feature/install-kubectl-kctl
 created: 2026-06-28
 updated: 2026-06-28
@@ -19,4 +19,5 @@ Create a repeatable installation and update script for `kubectl` (via Kubernetes
 - [x] Link the note in `docs/linux/Index.md`
 - [x] Verify/Test the script locally using dry-run or verification commands
 - [x] Update the Plan Index and Project Roadmap
+- [x] Create blog post in src/_posts/ promoting the KB note
 - [ ] Ask the user for confirmation and final review

--- a/.agent-brains/plan/install-kubectl-kctl/master-plan.md
+++ b/.agent-brains/plan/install-kubectl-kctl/master-plan.md
@@ -1,7 +1,7 @@
 ---
 task: install-kubectl-kctl
-status: active
-progress: 95
+status: done
+progress: 100
 branch: feature/install-kubectl-kctl
 created: 2026-06-28
 updated: 2026-06-28
@@ -20,4 +20,4 @@ Create a repeatable installation and update script for `kubectl` (via Kubernetes
 - [x] Verify/Test the script locally using dry-run or verification commands
 - [x] Update the Plan Index and Project Roadmap
 - [x] Create blog post in src/_posts/ promoting the KB note
-- [ ] Ask the user for confirmation and final review
+- [x] Ask the user for confirmation and final review

--- a/.agent-brains/plan/install-kubectl-kctl/master-plan.md
+++ b/.agent-brains/plan/install-kubectl-kctl/master-plan.md
@@ -7,16 +7,16 @@ created: 2026-06-28
 updated: 2026-06-28
 ---
 
-# Plan: Install kubectl and kctl on Debian/Ubuntu
+# Plan: Install kubectl, kubecolor, and kctl on Debian/Ubuntu
 
-Create a repeatable installation and update script for `kubectl` and `kctl` (as a symlink/alias), along with a local knowledge base document.
+Create a repeatable installation and update script for `kubectl`, `kubecolor`, and `kctl` (symlink to `kubecolor`), along with a local knowledge base document.
 
 ## Checklist
 
-- [x] Design the shell script features (preflight checks, architecture mapping, version comparison, `/usr/local/bin` installation, and shell auto-completion setup)
-- [x] Create the script file at `docs/linux/scripts/install-kubectl-kctl.sh`
-- [x] Create the documentation note at `docs/linux/install-kubectl-kctl.md`
+- [x] Design the shell script features (preflight checks, architecture mapping, version comparison, and installation logic)
+- [x] Add kubecolor download and installation logic, pointing kctl to kubecolor
+- [x] Update the documentation note at `docs/linux/install-kubectl-kctl.md`
 - [x] Link the note in `docs/linux/Index.md`
 - [x] Verify/Test the script locally using dry-run or verification commands
-- [x] Update the Plan Index and Project Roadmap
+- [ ] Update the Plan Index and Project Roadmap
 - [ ] Ask the user for confirmation and final review

--- a/.agent-brains/plan/pr-body.md
+++ b/.agent-brains/plan/pr-body.md
@@ -1,30 +1,12 @@
 ## What changed
-Restructured the repository into a dual-purpose workspace:
-
-- **`/docs`** — a local knowledge base of rough, internal notes organized into topic
-  folders, each with its own `Index.md`, plus a master `docs/Index.md`. Seeded by copying
-  seven existing notes (originals left untouched as a backup).
-- **`/src`** — the existing Jekyll + Chirpy blog, relocated from the repo root via `git mv`
-  so history is preserved (45 posts, CNAME, assets, theme config).
-
-Supporting changes:
-- Rewired both GitHub Pages workflows (`pages-build.yml`, `pages-deploy.yml`) to build from
-  `/src` (`working-directory: src`, artifact `path: src/_site...`) and to skip deploys for
-  `docs/**`-only changes.
-- Repointed the `.gitmodules` submodule path and root-anchored `.gitignore` patterns to `src/`.
-- Dropped stale `_config.yml` excludes that are now outside the Jekyll source.
-- Removed the already-migrated `Backup/` tree.
-- Rewrote `README.md` for the dual structure and the `/docs -> /src` promotion flow.
-- Documented the structure and a "write it down" note-capture rule in `.agent-brains/AGENT.md`,
-  and updated agent-brains plan/memory.
-
-Validated locally: `bundle install` + production `jekyll build` + `htmlproofer` all pass
-with 0 errors; CNAME is preserved in the built `_site`.
+Added a repeatable installer script, guide, and blog post for setting up `kubectl` and `kubecolor` on Debian/Ubuntu systems using `apt` and `.deb` packaging:
+- **`docs/linux/scripts/install-kubectl-kctl.sh`**: Installs `kubectl` via the official Kubernetes repository and `kubecolor` via the official release DEB package (verifying its SHA256 checksum). Creates a `kctl` symlink pointing to `kubecolor` for colorized output. Sets up tab completion for all commands.
+- **`docs/linux/install-kubectl-kctl.md`**: Guide explaining the installer script and manual step-by-step setup.
+- **`src/_posts/2026-06-28-debian-ubuntu-install-kubectl-kubecolor.md`**: Blog post promoting the setup guide.
+- Linked the guide in the Linux index and tracked it in agent-brains plan and memory structures.
 
 ## Why
-Make the repository serve both as a private working knowledge base and the public blog, with
-a clear promotion path from rough notes to published posts. no issue
+Make the setup and update of `kubectl` and `kubecolor` fully repeatable, utilizing the native `apt` package manager for clean dependency tracking and system integration, and alias `kubecolor` as `kctl` for faster typing.
 
 ## Breaking changes
-none -- the published site output and custom domain are unchanged; only the source layout and
-build working directory moved to `src/`.
+none

--- a/docs/linux/Index.md
+++ b/docs/linux/Index.md
@@ -4,3 +4,4 @@ Linux setup, configuration, desktop, and CLI notes.
 
 ## Notes
 - [Isolating Chromium Extension Apps on Linux (Wayland/X11)](edge_chrome_extension_pwa_isolation.md)
+- [Installing kubectl and kctl on Debian/Ubuntu](install-kubectl-kctl.md)

--- a/docs/linux/install-kubectl-kctl.md
+++ b/docs/linux/install-kubectl-kctl.md
@@ -1,16 +1,15 @@
-# Installing kubectl and kctl on Debian/Ubuntu
+# Installing kubectl, kubecolor, and kctl on Debian/Ubuntu
 
-This guide covers installing and upgrading `kubectl` (the official Kubernetes CLI) and `kctl` (a convenient symlink/alias for faster typing) on Debian/Ubuntu systems.
+This guide covers installing and upgrading `kubectl` (the official Kubernetes CLI), `kubecolor` (a wrapper that colorizes output for improved readability), and setting up `kctl` as a convenient command for `kubecolor`.
 
 An automated, repeatable installer and updater script is available in this repository at:
 [install-kubectl-kctl.sh](scripts/install-kubectl-kctl.sh)
 
-## Features
-- **Preflight Checks:** Verifies compatibility and that necessary dependencies (`curl`, `sudo`, `gpg`, `sha256sum`) are available.
-- **Idempotency:** Only downloads and installs when a new version is available or when forced.
-- **Checksum Verification:** Verifies the cryptographic SHA256 checksum of the downloaded binary before moving it to `/usr/local/bin`.
-- **System-Wide CLI Link:** Creates `/usr/local/bin/kctl` pointing to `/usr/local/bin/kubectl`.
-- **Shell Auto-Completion:** Automatically configures tab autocompletion for both `kubectl` and `kctl` in `.bashrc` and `.zshrc`.
+## How It Works
+1.  **kubectl Installation:** Installs or updates the official `kubectl` binary to `/usr/local/bin/kubectl`.
+2.  **kubecolor Installation:** Downloads the latest stable precompiled binary from `github.com/kubecolor/kubecolor` and installs it to `/usr/local/bin/kubecolor`.
+3.  **kctl Symlink:** Links `/usr/local/bin/kctl` directly to `kubecolor`. When you run `kctl`, it invokes `kubecolor`, which runs `kubectl` under the hood and colorizes the output.
+4.  **Tab Auto-Completion:** Automatically configures tab completion for `kubectl`, `kubecolor`, and `kctl` in `.bashrc` and `.zshrc`.
 
 ---
 
@@ -26,10 +25,11 @@ Run the script directly from the repository root:
 
 | Flag | Long Flag | Description |
 |------|-----------|-------------|
-| `-v` | `--version <VERSION>` | Install a specific version (e.g., `v1.30.0`) instead of the latest stable. |
-| `-f` | `--force` | Force download and installation even if already up to date. |
+| `-v` | `--version VERSION` | Install a specific kubectl version (e.g., `v1.30.0`) instead of the latest stable. |
+| `-k` | `--kubecolor-version VER` | Install a specific kubecolor version (e.g., `v0.6.0`) instead of the latest stable. |
+| `-f` | `--force` | Force download and installation of both binaries even if already up to date. |
 | `-c` | `--completion` | Automatically inject completion script settings into `~/.bashrc` and `~/.zshrc`. |
-| `-d` | `--dry-run` | Run preflight check and print actions, without modifying any files or downloading binaries. |
+| `-d` | `--dry-run` | Run preflight check and version comparison, but do not download or install. |
 | `-h` | `--help` | Display the usage menu. |
 
 ### Examples
@@ -44,9 +44,9 @@ Run the script directly from the repository root:
 ./docs/linux/scripts/install-kubectl-kctl.sh --completion
 ```
 
-**3. Install or downgrade to a specific version (e.g., v1.31.1):**
+**3. Install specific versions:**
 ```bash
-./docs/linux/scripts/install-kubectl-kctl.sh --version v1.31.1
+./docs/linux/scripts/install-kubectl-kctl.sh --version v1.31.1 --kubecolor-version v0.6.0
 ```
 
 ---
@@ -58,10 +58,11 @@ If you choose not to run the script with the `-c` / `--completion` flag, you can
 ### Bash (`~/.bashrc`)
 Add this block at the end of your `~/.bashrc`:
 ```bash
-# Kubernetes completion
+# Kubernetes and Kubecolor completion
 if command -v kubectl >/dev/null 2>&1; then
   source <(kubectl completion bash)
-  complete -o default -F __start_kubectl kctl
+  complete -o default -F __start_kubectl kubecolor 2>/dev/null || true
+  complete -o default -F __start_kubectl kctl 2>/dev/null || true
 fi
 ```
 Then reload with:
@@ -72,10 +73,11 @@ source ~/.bashrc
 ### Zsh (`~/.zshrc`)
 Add this block at the end of your `~/.zshrc`:
 ```bash
-# Kubernetes completion
+# Kubernetes and Kubecolor completion
 if command -v kubectl >/dev/null 2>&1; then
   source <(kubectl completion zsh)
-  compdef __start_kubectl kctl
+  compdef __start_kubectl kubecolor 2>/dev/null || true
+  compdef __start_kubectl kctl 2>/dev/null || true
 fi
 ```
 Then reload with:

--- a/docs/linux/install-kubectl-kctl.md
+++ b/docs/linux/install-kubectl-kctl.md
@@ -1,0 +1,84 @@
+# Installing kubectl and kctl on Debian/Ubuntu
+
+This guide covers installing and upgrading `kubectl` (the official Kubernetes CLI) and `kctl` (a convenient symlink/alias for faster typing) on Debian/Ubuntu systems.
+
+An automated, repeatable installer and updater script is available in this repository at:
+[install-kubectl-kctl.sh](scripts/install-kubectl-kctl.sh)
+
+## Features
+- **Preflight Checks:** Verifies compatibility and that necessary dependencies (`curl`, `sudo`, `gpg`, `sha256sum`) are available.
+- **Idempotency:** Only downloads and installs when a new version is available or when forced.
+- **Checksum Verification:** Verifies the cryptographic SHA256 checksum of the downloaded binary before moving it to `/usr/local/bin`.
+- **System-Wide CLI Link:** Creates `/usr/local/bin/kctl` pointing to `/usr/local/bin/kubectl`.
+- **Shell Auto-Completion:** Automatically configures tab autocompletion for both `kubectl` and `kctl` in `.bashrc` and `.zshrc`.
+
+---
+
+## Script Usage
+
+Run the script directly from the repository root:
+
+```bash
+./docs/linux/scripts/install-kubectl-kctl.sh [options]
+```
+
+### Options
+
+| Flag | Long Flag | Description |
+|------|-----------|-------------|
+| `-v` | `--version <VERSION>` | Install a specific version (e.g., `v1.30.0`) instead of the latest stable. |
+| `-f` | `--force` | Force download and installation even if already up to date. |
+| `-c` | `--completion` | Automatically inject completion script settings into `~/.bashrc` and `~/.zshrc`. |
+| `-d` | `--dry-run` | Run preflight check and print actions, without modifying any files or downloading binaries. |
+| `-h` | `--help` | Display the usage menu. |
+
+### Examples
+
+**1. Dry-run to preview actions:**
+```bash
+./docs/linux/scripts/install-kubectl-kctl.sh --dry-run
+```
+
+**2. Standard install / update to latest stable with auto-completion configuration:**
+```bash
+./docs/linux/scripts/install-kubectl-kctl.sh --completion
+```
+
+**3. Install or downgrade to a specific version (e.g., v1.31.1):**
+```bash
+./docs/linux/scripts/install-kubectl-kctl.sh --version v1.31.1
+```
+
+---
+
+## Manual Setup & Auto-Completion Details
+
+If you choose not to run the script with the `-c` / `--completion` flag, you can set up autocompletion manually by appending the following configurations to your shell configuration file.
+
+### Bash (`~/.bashrc`)
+Add this block at the end of your `~/.bashrc`:
+```bash
+# Kubernetes completion
+if command -v kubectl >/dev/null 2>&1; then
+  source <(kubectl completion bash)
+  complete -o default -F __start_kubectl kctl
+fi
+```
+Then reload with:
+```bash
+source ~/.bashrc
+```
+
+### Zsh (`~/.zshrc`)
+Add this block at the end of your `~/.zshrc`:
+```bash
+# Kubernetes completion
+if command -v kubectl >/dev/null 2>&1; then
+  source <(kubectl completion zsh)
+  compdef __start_kubectl kctl
+fi
+```
+Then reload with:
+```bash
+source ~/.zshrc
+```

--- a/docs/linux/install-kubectl-kctl.md
+++ b/docs/linux/install-kubectl-kctl.md
@@ -1,4 +1,4 @@
-# Installing kubectl, kubecolor, and kctl on Debian/Ubuntu
+# Installing kubectl, kubecolor, and kctl on Debian/Ubuntu via APT
 
 This guide covers installing and upgrading `kubectl` (the official Kubernetes CLI), `kubecolor` (a wrapper that colorizes output for improved readability), and setting up `kctl` as a convenient command for `kubecolor`.
 
@@ -6,9 +6,9 @@ An automated, repeatable installer and updater script is available in this repos
 [install-kubectl-kctl.sh](scripts/install-kubectl-kctl.sh)
 
 ## How It Works
-1.  **kubectl Installation:** Installs or updates the official `kubectl` binary to `/usr/local/bin/kubectl`.
-2.  **kubecolor Installation:** Downloads the latest stable precompiled binary from `github.com/kubecolor/kubecolor` and installs it to `/usr/local/bin/kubecolor`.
-3.  **kctl Symlink:** Links `/usr/local/bin/kctl` directly to `kubecolor`. When you run `kctl`, it invokes `kubecolor`, which runs `kubectl` under the hood and colorizes the output.
+1.  **kubectl Installation (APT Repo):** Registers the official Kubernetes APT repository (`pkgs.k8s.io`) and installs/upgrades `kubectl` to `/usr/bin/kubectl` via `apt-get`.
+2.  **kubecolor Installation (DEB package):** Downloads the latest stable precompiled DEB package from `github.com/kubecolor/kubecolor`, verifies its cryptographic SHA256 checksum, and installs it via `apt-get` (allowing system tracking and dependency resolution). It is installed to `/usr/bin/kubecolor`.
+3.  **kctl Symlink:** Links `/usr/local/bin/kctl` directly to `/usr/bin/kubecolor`. Running `kctl` invokes `kubecolor`, which runs `kubectl` under the hood and colorizes the output.
 4.  **Tab Auto-Completion:** Automatically configures tab completion for `kubectl`, `kubecolor`, and `kctl` in `.bashrc` and `.zshrc`.
 
 ---
@@ -27,26 +27,26 @@ Run the script directly from the repository root:
 |------|-----------|-------------|
 | `-v` | `--version VERSION` | Install a specific kubectl version (e.g., `v1.30.0`) instead of the latest stable. |
 | `-k` | `--kubecolor-version VER` | Install a specific kubecolor version (e.g., `v0.6.0`) instead of the latest stable. |
-| `-f` | `--force` | Force download and installation of both binaries even if already up to date. |
+| `-f` | `--force` | Force repository setup and package reinstall even if already up to date. |
 | `-c` | `--completion` | Automatically inject completion script settings into `~/.bashrc` and `~/.zshrc`. |
 | `-d` | `--dry-run` | Run preflight check and version comparison, but do not download or install. |
 | `-h` | `--help` | Display the usage menu. |
 
 ### Examples
 
-**1. Dry-run to preview actions:**
+**1. Dry-run to preview APT repository setup and package installation:**
 ```bash
 ./docs/linux/scripts/install-kubectl-kctl.sh --dry-run
 ```
 
-**2. Standard install / update to latest stable with auto-completion configuration:**
+**2. Standard install / update via APT with auto-completion configuration:**
 ```bash
 ./docs/linux/scripts/install-kubectl-kctl.sh --completion
 ```
 
-**3. Install specific versions:**
+**3. Install specific minor version of kubectl and specific version of kubecolor:**
 ```bash
-./docs/linux/scripts/install-kubectl-kctl.sh --version v1.31.1 --kubecolor-version v0.6.0
+./docs/linux/scripts/install-kubectl-kctl.sh --version v1.30.5 --kubecolor-version v0.6.0
 ```
 
 ---

--- a/docs/linux/scripts/install-kubectl-kctl.sh
+++ b/docs/linux/scripts/install-kubectl-kctl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # install-kubectl-kctl.sh
-# Idempotent installer/updater for kubectl and kctl on Debian/Ubuntu systems.
+# Idempotent installer/updater for kubectl, kubecolor, and kctl (symlink) on Debian/Ubuntu systems.
 # Performs preflight checks, architecture detection, checksum validation,
 # system-wide installation, and optional shell completion setup.
 #
@@ -11,30 +11,42 @@ set -euo pipefail
 # Default variables
 TARGET_DIR="/usr/local/bin"
 KUBECTL_BIN="${TARGET_DIR}/kubectl"
+KUBECOLOR_BIN="${TARGET_DIR}/kubecolor"
 KCTL_LINK="${TARGET_DIR}/kctl"
 FORCE=false
 DRY_RUN=false
-SPECIFIED_VERSION=""
+KUBECTL_VERSION=""
+KUBECOLOR_VERSION=""
 SETUP_COMPLETION=false
+TMP_DIR=""
 
 # Print logs with colors
 log_info() { echo -e "\e[32m[INFO]\e[0m $*"; }
 log_warn() { echo -e "\e[33m[WARN]\e[0m $*"; }
 log_err()  { echo -e "\e[31m[ERROR]\e[0m $*" >&2; }
 
+# Cleanup hook for temp files
+cleanup() {
+  if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
 # Help menu
 show_help() {
   cat << EOF
 Usage: $(basename "$0") [options]
 
-Install or update 'kubectl' and 'kctl' (symlink) on Debian/Ubuntu.
+Install or update 'kubectl', 'kubecolor', and 'kctl' (symlink to kubecolor) on Debian/Ubuntu.
 
 Options:
-  -v, --version VERSION  Install a specific version (e.g., v1.30.0) instead of latest stable.
-  -f, --force            Force installation/download even if already up-to-date.
-  -c, --completion       Configure shell autocompletion for kubectl and kctl in ~/.bashrc and ~/.zshrc.
-  -d, --dry-run          Run preflight checks and version comparison, but do not download or install.
-  -h, --help             Show this help message.
+  -v, --version VERSION       Install a specific kubectl version (e.g., v1.30.0) instead of latest stable.
+  -k, --kubecolor-version VER Install a specific kubecolor version (e.g., v0.6.0) instead of latest stable.
+  -f, --force                 Force installation/download even if already up-to-date.
+  -c, --completion            Configure shell autocompletion for kubectl, kubecolor, and kctl in ~/.bashrc and ~/.zshrc.
+  -d, --dry-run               Run preflight checks and version comparison, but do not download or install.
+  -h, --help                  Show this help message.
 EOF
 }
 
@@ -42,7 +54,11 @@ EOF
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -v|--version)
-      SPECIFIED_VERSION="$2"
+      KUBECTL_VERSION="$2"
+      shift 2
+      ;;
+    -k|--kubecolor-version)
+      KUBECOLOR_VERSION="$2"
       shift 2
       ;;
     -f|--force)
@@ -85,7 +101,7 @@ preflight_checks() {
   fi
 
   # Check required commands
-  for cmd in curl gpg grep cut sha256sum; do
+  for cmd in curl gpg grep cut sha256sum tar; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
       log_err "Required command '$cmd' is not installed. Please install it first."
       exit 1
@@ -126,102 +142,177 @@ detect_arch() {
 
 # 3. Determine versions
 resolve_versions() {
-  # Get latest stable version
+  # Get latest stable kubectl version
   log_info "Fetching latest stable kubectl version..."
-  LATEST_VERSION=$(curl -sSL https://dl.k8s.io/release/stable.txt)
-  if [[ -z "$LATEST_VERSION" ]]; then
-    log_err "Failed to fetch latest stable version from Kubernetes release site."
+  local latest_kubectl
+  latest_kubectl=$(curl -sSL https://dl.k8s.io/release/stable.txt)
+  if [[ -z "$latest_kubectl" ]]; then
+    log_err "Failed to fetch latest stable kubectl version."
     exit 1
   fi
-  log_info "Latest stable version is $LATEST_VERSION"
-
-  TARGET_VERSION="${SPECIFIED_VERSION:-$LATEST_VERSION}"
-  # Ensure version starts with 'v'
-  if [[ ! "$TARGET_VERSION" =~ ^v ]]; then
-    TARGET_VERSION="v${TARGET_VERSION}"
+  TARGET_KUBECTL_VERSION="${KUBECTL_VERSION:-$latest_kubectl}"
+  if [[ ! "$TARGET_KUBECTL_VERSION" =~ ^v ]]; then
+    TARGET_KUBECTL_VERSION="v${TARGET_KUBECTL_VERSION}"
   fi
-  log_info "Target version to install: $TARGET_VERSION"
+  log_info "Target kubectl version: $TARGET_KUBECTL_VERSION"
 
-  # Check installed version
+  # Check installed kubectl version
   if command -v kubectl >/dev/null 2>&1; then
-    # We parse version safely
-    INSTALLED_VERSION=$(kubectl version --client 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
-    if [[ -n "$INSTALLED_VERSION" ]]; then
-      log_info "Currently installed kubectl version: $INSTALLED_VERSION"
+    INSTALLED_KUBECTL_VERSION=$(kubectl version --client 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
+    if [[ -n "$INSTALLED_KUBECTL_VERSION" ]]; then
+      log_info "Currently installed kubectl version: $INSTALLED_KUBECTL_VERSION"
     else
       log_warn "kubectl binary found but version could not be parsed."
-      INSTALLED_VERSION="none"
+      INSTALLED_KUBECTL_VERSION="none"
     fi
   else
-    INSTALLED_VERSION="none"
+    INSTALLED_KUBECTL_VERSION="none"
     log_info "kubectl is not currently installed."
+  fi
+
+  # Get latest stable kubecolor version
+  log_info "Fetching latest stable kubecolor version..."
+  local redirect_url
+  redirect_url=$(curl -sSfL -o /dev/null -w "%{url_effective}" https://github.com/kubecolor/kubecolor/releases/latest || true)
+  local latest_kubecolor="v0.6.0"
+  if [[ -n "$redirect_url" ]]; then
+    latest_kubecolor="${redirect_url##*/}"
+  fi
+  TARGET_KUBECOLOR_VERSION="${KUBECOLOR_VERSION:-$latest_kubecolor}"
+  if [[ ! "$TARGET_KUBECOLOR_VERSION" =~ ^v ]]; then
+    TARGET_KUBECOLOR_VERSION="v${TARGET_KUBECOLOR_VERSION}"
+  fi
+  log_info "Target kubecolor version: $TARGET_KUBECOLOR_VERSION"
+
+  # Check installed kubecolor version
+  if command -v kubecolor >/dev/null 2>&1; then
+    INSTALLED_KUBECOLOR_VERSION=$(kubecolor --kubecolor-version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
+    if [[ -n "$INSTALLED_KUBECOLOR_VERSION" ]]; then
+      log_info "Currently installed kubecolor version: $INSTALLED_KUBECOLOR_VERSION"
+    else
+      log_warn "kubecolor binary found but version could not be parsed."
+      INSTALLED_KUBECOLOR_VERSION="none"
+    fi
+  else
+    INSTALLED_KUBECOLOR_VERSION="none"
+    log_info "kubecolor is not currently installed."
   fi
 }
 
-# 4. Perform Download and Installation
+# 4. Perform Download and Installation of kubectl
 install_kubectl() {
-  if [[ "$INSTALLED_VERSION" == "$TARGET_VERSION" ]] && [[ "$FORCE" = "false" ]]; then
-    log_info "kubectl is already at the target version ($TARGET_VERSION). Skipping installation."
+  if [[ "$INSTALLED_KUBECTL_VERSION" == "$TARGET_KUBECTL_VERSION" ]] && [[ "$FORCE" = "false" ]]; then
+    log_info "kubectl is already at the target version ($TARGET_KUBECTL_VERSION). Skipping installation."
     return
   fi
 
   if [[ "$DRY_RUN" = "true" ]]; then
-    log_info "[DRY-RUN] Would install kubectl version $TARGET_VERSION to $KUBECTL_BIN"
+    log_info "[DRY-RUN] Would install kubectl version $TARGET_KUBECTL_VERSION to $KUBECTL_BIN"
     return
   fi
 
-  log_info "Downloading kubectl binary for $ARCH..."
-  local tmp_dir
-  tmp_dir=$(mktemp -d)
-  trap 'rm -rf "$tmp_dir"' EXIT
-
-  local bin_url="https://dl.k8s.io/release/${TARGET_VERSION}/bin/linux/${ARCH}/kubectl"
+  log_info "Downloading kubectl binary..."
+  local bin_url="https://dl.k8s.io/release/${TARGET_KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
   local sha_url="${bin_url}.sha256"
 
   # Download binary and checksum
-  curl -L -sS -o "${tmp_dir}/kubectl" "$bin_url"
-  curl -L -sS -o "${tmp_dir}/kubectl.sha256" "$sha_url"
+  curl -L -sS -o "${TMP_DIR}/kubectl" "$bin_url"
+  curl -L -sS -o "${TMP_DIR}/kubectl.sha256" "$sha_url"
 
   # Validate checksum
-  log_info "Verifying SHA256 checksum..."
+  log_info "Verifying SHA256 checksum for kubectl..."
   local expected_sha
-  expected_sha=$(cat "${tmp_dir}/kubectl.sha256")
+  expected_sha=$(cat "${TMP_DIR}/kubectl.sha256")
   local actual_sha
-  actual_sha=$(sha256sum "${tmp_dir}/kubectl" | cut -d' ' -f1)
+  actual_sha=$(sha256sum "${TMP_DIR}/kubectl" | cut -d' ' -f1)
 
   if [[ "$expected_sha" != "$actual_sha" ]]; then
-    log_err "Checksum verification failed!"
+    log_err "kubectl checksum verification failed!"
     log_err "Expected: $expected_sha"
     log_err "Actual:   $actual_sha"
     exit 1
   fi
-  log_info "Checksum verification succeeded."
+  log_info "kubectl checksum verification succeeded."
 
   # Install binary
   log_info "Installing kubectl binary to $KUBECTL_BIN..."
-  chmod +x "${tmp_dir}/kubectl"
+  chmod +x "${TMP_DIR}/kubectl"
   if [[ $EUID -eq 0 ]]; then
-    mv "${tmp_dir}/kubectl" "$KUBECTL_BIN"
+    mv "${TMP_DIR}/kubectl" "$KUBECTL_BIN"
   else
-    sudo mv "${tmp_dir}/kubectl" "$KUBECTL_BIN"
+    sudo mv "${TMP_DIR}/kubectl" "$KUBECTL_BIN"
     sudo chown root:root "$KUBECTL_BIN"
   fi
   log_info "kubectl version $(kubectl version --client | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1) installed successfully."
 }
 
-# 5. Create kctl symlink
-create_symlink() {
-  if [[ "$DRY_RUN" = "true" ]]; then
-    log_info "[DRY-RUN] Would create symlink $KCTL_LINK -> $KUBECTL_BIN"
+# 5. Perform Download and Installation of kubecolor
+install_kubecolor() {
+  if [[ "$INSTALLED_KUBECOLOR_VERSION" == "$TARGET_KUBECOLOR_VERSION" ]] && [[ "$FORCE" = "false" ]]; then
+    log_info "kubecolor is already at the target version ($TARGET_KUBECOLOR_VERSION). Skipping installation."
     return
   fi
 
-  log_info "Ensuring 'kctl' symlink points to 'kubectl'..."
+  if [[ "$DRY_RUN" = "true" ]]; then
+    log_info "[DRY-RUN] Would install kubecolor version $TARGET_KUBECOLOR_VERSION to $KUBECOLOR_BIN"
+    return
+  fi
+
+  log_info "Downloading kubecolor archive..."
+  local kubecolor_no_v="${TARGET_KUBECOLOR_VERSION#v}"
+  local bin_url="https://github.com/kubecolor/kubecolor/releases/download/${TARGET_KUBECOLOR_VERSION}/kubecolor_${kubecolor_no_v}_linux_${ARCH}.tar.gz"
+  local sha_url="https://github.com/kubecolor/kubecolor/releases/download/${TARGET_KUBECOLOR_VERSION}/checksums.txt"
+
+  # Download binary archive and checksums
+  curl -L -sS -o "${TMP_DIR}/kubecolor.tar.gz" "$bin_url"
+  curl -L -sS -o "${TMP_DIR}/checksums.txt" "$sha_url"
+
+  # Validate checksum
+  log_info "Verifying SHA256 checksum for kubecolor..."
+  local tarball_name="kubecolor_${kubecolor_no_v}_linux_${ARCH}.tar.gz"
+  if ! grep -q "$tarball_name" "${TMP_DIR}/checksums.txt"; then
+    log_err "Tarball entry '$tarball_name' not found in checksums.txt."
+    exit 1
+  fi
+
+  # Extract matching line
+  grep "$tarball_name" "${TMP_DIR}/checksums.txt" > "${TMP_DIR}/kubecolor.sha256"
+  
+  if ! (cd "$TMP_DIR" && sha256sum --check --status kubecolor.sha256); then
+    log_err "kubecolor checksum verification failed for $tarball_name!"
+    exit 1
+  fi
+  log_info "kubecolor checksum verification succeeded."
+
+  # Extract binary
+  log_info "Extracting kubecolor binary..."
+  tar -xzf "${TMP_DIR}/kubecolor.tar.gz" -C "$TMP_DIR" kubecolor
+
+  # Install binary
+  log_info "Installing kubecolor binary to $KUBECOLOR_BIN..."
+  chmod +x "${TMP_DIR}/kubecolor"
+  if [[ $EUID -eq 0 ]]; then
+    mv "${TMP_DIR}/kubecolor" "$KUBECOLOR_BIN"
+  else
+    sudo mv "${TMP_DIR}/kubecolor" "$KUBECOLOR_BIN"
+    sudo chown root:root "$KUBECOLOR_BIN"
+  fi
+  log_info "kubecolor version $(kubecolor --kubecolor-version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1) installed successfully."
+}
+
+# 6. Create kctl symlink
+create_symlink() {
+  if [[ "$DRY_RUN" = "true" ]]; then
+    log_info "[DRY-RUN] Would create symlink $KCTL_LINK -> $KUBECOLOR_BIN"
+    return
+  fi
+
+  log_info "Ensuring 'kctl' symlink points to 'kubecolor'..."
   if [[ -L "$KCTL_LINK" ]]; then
     local current_target
     current_target=$(readlink -f "$KCTL_LINK" || true)
-    if [[ "$current_target" == "$KUBECTL_BIN" ]]; then
-      log_info "Symlink $KCTL_LINK already exists and points to $KUBECTL_BIN."
+    if [[ "$current_target" == "$KUBECOLOR_BIN" ]]; then
+      log_info "Symlink $KCTL_LINK already exists and points to $KUBECOLOR_BIN."
       return
     fi
     log_warn "Symlink $KCTL_LINK points to $current_target. Re-creating..."
@@ -235,22 +326,22 @@ create_symlink() {
   fi
 
   if [[ $EUID -eq 0 ]]; then
-    ln -sf "$KUBECTL_BIN" "$KCTL_LINK"
+    ln -sf "$KUBECOLOR_BIN" "$KCTL_LINK"
   else
-    sudo ln -sf "$KUBECTL_BIN" "$KCTL_LINK"
+    sudo ln -sf "$KUBECOLOR_BIN" "$KCTL_LINK"
   fi
   log_info "Symlink $KCTL_LINK created successfully."
 }
 
-# 6. Configure Autocompletion
+# 7. Configure Autocompletion
 configure_completion() {
   if [[ "$SETUP_COMPLETION" = "false" ]]; then
     log_info "Skipping automatic shell completion setup. Use -c or --completion to configure it."
     log_info "Manual setup instructions:"
     log_info "  For Bash: echo 'source <(kubectl completion bash)' >> ~/.bashrc"
-    log_info "            echo 'complete -o default -F __start_kubectl kctl' >> ~/.bashrc"
+    log_info "            echo 'complete -o default -F __start_kubectl kubecolor kctl' >> ~/.bashrc"
     log_info "  For Zsh:  echo 'source <(kubectl completion zsh)' >> ~/.zshrc"
-    log_info "            echo 'compdef __start_kubectl kctl' >> ~/.zshrc"
+    log_info "            echo 'compdef __start_kubectl kubecolor kctl' >> ~/.zshrc"
     return
   fi
 
@@ -265,10 +356,11 @@ configure_completion() {
     if ! grep -q "kubectl completion bash" "$HOME/.bashrc"; then
       cat << 'EOF' >> "$HOME/.bashrc"
 
-# Kubernetes completion
+# Kubernetes and Kubecolor completion
 if command -v kubectl >/dev/null 2>&1; then
   source <(kubectl completion bash)
-  complete -o default -F __start_kubectl kctl
+  complete -o default -F __start_kubectl kubecolor 2>/dev/null || true
+  complete -o default -F __start_kubectl kctl 2>/dev/null || true
 fi
 EOF
       log_info "Bash completion added. Run 'source ~/.bashrc' to apply."
@@ -283,10 +375,11 @@ EOF
     if ! grep -q "kubectl completion zsh" "$HOME/.zshrc"; then
       cat << 'EOF' >> "$HOME/.zshrc"
 
-# Kubernetes completion
+# Kubernetes and Kubecolor completion
 if command -v kubectl >/dev/null 2>&1; then
   source <(kubectl completion zsh)
-  compdef __start_kubectl kctl
+  compdef __start_kubectl kubecolor 2>/dev/null || true
+  compdef __start_kubectl kctl 2>/dev/null || true
 fi
 EOF
       log_info "Zsh completion added. Run 'source ~/.zshrc' to apply."
@@ -300,7 +393,14 @@ main() {
   preflight_checks
   detect_arch
   resolve_versions
+  
+  # Create temp workspace
+  if [[ "$DRY_RUN" = "false" ]]; then
+    TMP_DIR=$(mktemp -d)
+  fi
+
   install_kubectl
+  install_kubecolor
   create_symlink
   configure_completion
   log_info "All tasks completed successfully."

--- a/docs/linux/scripts/install-kubectl-kctl.sh
+++ b/docs/linux/scripts/install-kubectl-kctl.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+#
+# install-kubectl-kctl.sh
+# Idempotent installer/updater for kubectl and kctl on Debian/Ubuntu systems.
+# Performs preflight checks, architecture detection, checksum validation,
+# system-wide installation, and optional shell completion setup.
+#
+
+set -euo pipefail
+
+# Default variables
+TARGET_DIR="/usr/local/bin"
+KUBECTL_BIN="${TARGET_DIR}/kubectl"
+KCTL_LINK="${TARGET_DIR}/kctl"
+FORCE=false
+DRY_RUN=false
+SPECIFIED_VERSION=""
+SETUP_COMPLETION=false
+
+# Print logs with colors
+log_info() { echo -e "\e[32m[INFO]\e[0m $*"; }
+log_warn() { echo -e "\e[33m[WARN]\e[0m $*"; }
+log_err()  { echo -e "\e[31m[ERROR]\e[0m $*" >&2; }
+
+# Help menu
+show_help() {
+  cat << EOF
+Usage: $(basename "$0") [options]
+
+Install or update 'kubectl' and 'kctl' (symlink) on Debian/Ubuntu.
+
+Options:
+  -v, --version VERSION  Install a specific version (e.g., v1.30.0) instead of latest stable.
+  -f, --force            Force installation/download even if already up-to-date.
+  -c, --completion       Configure shell autocompletion for kubectl and kctl in ~/.bashrc and ~/.zshrc.
+  -d, --dry-run          Run preflight checks and version comparison, but do not download or install.
+  -h, --help             Show this help message.
+EOF
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -v|--version)
+      SPECIFIED_VERSION="$2"
+      shift 2
+      ;;
+    -f|--force)
+      FORCE=true
+      shift
+      ;;
+    -c|--completion)
+      SETUP_COMPLETION=true
+      shift
+      ;;
+    -d|--dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      log_err "Unknown option: $1"
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+# 1. Preflight checks
+preflight_checks() {
+  log_info "Running preflight checks..."
+
+  # OS Verification
+  if [[ ! -f /etc/os-release ]]; then
+    log_err "Cannot verify OS: /etc/os-release is missing. This script targets Debian/Ubuntu."
+    exit 1
+  fi
+
+  # Support Debian or Ubuntu or derivatives
+  if ! grep -qEi 'debian|ubuntu' /etc/os-release; then
+    log_warn "This script targets Debian/Ubuntu. Your OS might not be fully compatible."
+  fi
+
+  # Check required commands
+  for cmd in curl gpg grep cut sha256sum; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      log_err "Required command '$cmd' is not installed. Please install it first."
+      exit 1
+    fi
+  done
+
+  # Sudo verification (only if NOT dry-run, and installing/symlinking is needed)
+  if [[ "$DRY_RUN" = "false" ]]; then
+    if [[ $EUID -ne 0 ]]; then
+      if ! command -v sudo >/dev/null 2>&1; then
+        log_err "This script must be run as root (or with sudo), and 'sudo' is not installed."
+        exit 1
+      fi
+      # Check if user has sudo privileges
+      if ! sudo -n true 2>/dev/null; then
+        log_info "Sudo privileges required. You may be prompted for your password."
+      fi
+    fi
+  fi
+
+  log_info "Preflight checks passed."
+}
+
+# 2. Detect System Architecture
+detect_arch() {
+  local machine
+  machine=$(uname -m)
+  case "$machine" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    *)
+      log_err "Unsupported architecture: $machine. Only x86_64 and arm64/aarch64 are supported."
+      exit 1
+      ;;
+  esac
+  log_info "Detected architecture: $ARCH ($machine)"
+}
+
+# 3. Determine versions
+resolve_versions() {
+  # Get latest stable version
+  log_info "Fetching latest stable kubectl version..."
+  LATEST_VERSION=$(curl -sSL https://dl.k8s.io/release/stable.txt)
+  if [[ -z "$LATEST_VERSION" ]]; then
+    log_err "Failed to fetch latest stable version from Kubernetes release site."
+    exit 1
+  fi
+  log_info "Latest stable version is $LATEST_VERSION"
+
+  TARGET_VERSION="${SPECIFIED_VERSION:-$LATEST_VERSION}"
+  # Ensure version starts with 'v'
+  if [[ ! "$TARGET_VERSION" =~ ^v ]]; then
+    TARGET_VERSION="v${TARGET_VERSION}"
+  fi
+  log_info "Target version to install: $TARGET_VERSION"
+
+  # Check installed version
+  if command -v kubectl >/dev/null 2>&1; then
+    # We parse version safely
+    INSTALLED_VERSION=$(kubectl version --client 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
+    if [[ -n "$INSTALLED_VERSION" ]]; then
+      log_info "Currently installed kubectl version: $INSTALLED_VERSION"
+    else
+      log_warn "kubectl binary found but version could not be parsed."
+      INSTALLED_VERSION="none"
+    fi
+  else
+    INSTALLED_VERSION="none"
+    log_info "kubectl is not currently installed."
+  fi
+}
+
+# 4. Perform Download and Installation
+install_kubectl() {
+  if [[ "$INSTALLED_VERSION" == "$TARGET_VERSION" ]] && [[ "$FORCE" = "false" ]]; then
+    log_info "kubectl is already at the target version ($TARGET_VERSION). Skipping installation."
+    return
+  fi
+
+  if [[ "$DRY_RUN" = "true" ]]; then
+    log_info "[DRY-RUN] Would install kubectl version $TARGET_VERSION to $KUBECTL_BIN"
+    return
+  fi
+
+  log_info "Downloading kubectl binary for $ARCH..."
+  local tmp_dir
+  tmp_dir=$(mktemp -d)
+  trap 'rm -rf "$tmp_dir"' EXIT
+
+  local bin_url="https://dl.k8s.io/release/${TARGET_VERSION}/bin/linux/${ARCH}/kubectl"
+  local sha_url="${bin_url}.sha256"
+
+  # Download binary and checksum
+  curl -L -sS -o "${tmp_dir}/kubectl" "$bin_url"
+  curl -L -sS -o "${tmp_dir}/kubectl.sha256" "$sha_url"
+
+  # Validate checksum
+  log_info "Verifying SHA256 checksum..."
+  local expected_sha
+  expected_sha=$(cat "${tmp_dir}/kubectl.sha256")
+  local actual_sha
+  actual_sha=$(sha256sum "${tmp_dir}/kubectl" | cut -d' ' -f1)
+
+  if [[ "$expected_sha" != "$actual_sha" ]]; then
+    log_err "Checksum verification failed!"
+    log_err "Expected: $expected_sha"
+    log_err "Actual:   $actual_sha"
+    exit 1
+  fi
+  log_info "Checksum verification succeeded."
+
+  # Install binary
+  log_info "Installing kubectl binary to $KUBECTL_BIN..."
+  chmod +x "${tmp_dir}/kubectl"
+  if [[ $EUID -eq 0 ]]; then
+    mv "${tmp_dir}/kubectl" "$KUBECTL_BIN"
+  else
+    sudo mv "${tmp_dir}/kubectl" "$KUBECTL_BIN"
+    sudo chown root:root "$KUBECTL_BIN"
+  fi
+  log_info "kubectl version $(kubectl version --client | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1) installed successfully."
+}
+
+# 5. Create kctl symlink
+create_symlink() {
+  if [[ "$DRY_RUN" = "true" ]]; then
+    log_info "[DRY-RUN] Would create symlink $KCTL_LINK -> $KUBECTL_BIN"
+    return
+  fi
+
+  log_info "Ensuring 'kctl' symlink points to 'kubectl'..."
+  if [[ -L "$KCTL_LINK" ]]; then
+    local current_target
+    current_target=$(readlink -f "$KCTL_LINK" || true)
+    if [[ "$current_target" == "$KUBECTL_BIN" ]]; then
+      log_info "Symlink $KCTL_LINK already exists and points to $KUBECTL_BIN."
+      return
+    fi
+    log_warn "Symlink $KCTL_LINK points to $current_target. Re-creating..."
+  elif [[ -e "$KCTL_LINK" ]]; then
+    log_warn "A non-symlink file exists at $KCTL_LINK. Removing..."
+    if [[ $EUID -eq 0 ]]; then
+      rm -f "$KCTL_LINK"
+    else
+      sudo rm -f "$KCTL_LINK"
+    fi
+  fi
+
+  if [[ $EUID -eq 0 ]]; then
+    ln -sf "$KUBECTL_BIN" "$KCTL_LINK"
+  else
+    sudo ln -sf "$KUBECTL_BIN" "$KCTL_LINK"
+  fi
+  log_info "Symlink $KCTL_LINK created successfully."
+}
+
+# 6. Configure Autocompletion
+configure_completion() {
+  if [[ "$SETUP_COMPLETION" = "false" ]]; then
+    log_info "Skipping automatic shell completion setup. Use -c or --completion to configure it."
+    log_info "Manual setup instructions:"
+    log_info "  For Bash: echo 'source <(kubectl completion bash)' >> ~/.bashrc"
+    log_info "            echo 'complete -o default -F __start_kubectl kctl' >> ~/.bashrc"
+    log_info "  For Zsh:  echo 'source <(kubectl completion zsh)' >> ~/.zshrc"
+    log_info "            echo 'compdef __start_kubectl kctl' >> ~/.zshrc"
+    return
+  fi
+
+  if [[ "$DRY_RUN" = "true" ]]; then
+    log_info "[DRY-RUN] Would configure completion in ~/.bashrc and ~/.zshrc"
+    return
+  fi
+
+  # For Bash
+  if [[ -f "$HOME/.bashrc" ]]; then
+    log_info "Configuring autocompletion in ~/.bashrc..."
+    if ! grep -q "kubectl completion bash" "$HOME/.bashrc"; then
+      cat << 'EOF' >> "$HOME/.bashrc"
+
+# Kubernetes completion
+if command -v kubectl >/dev/null 2>&1; then
+  source <(kubectl completion bash)
+  complete -o default -F __start_kubectl kctl
+fi
+EOF
+      log_info "Bash completion added. Run 'source ~/.bashrc' to apply."
+    else
+      log_info "Bash completion already configured in ~/.bashrc."
+    fi
+  fi
+
+  # For Zsh
+  if [[ -f "$HOME/.zshrc" ]]; then
+    log_info "Configuring autocompletion in ~/.zshrc..."
+    if ! grep -q "kubectl completion zsh" "$HOME/.zshrc"; then
+      cat << 'EOF' >> "$HOME/.zshrc"
+
+# Kubernetes completion
+if command -v kubectl >/dev/null 2>&1; then
+  source <(kubectl completion zsh)
+  compdef __start_kubectl kctl
+fi
+EOF
+      log_info "Zsh completion added. Run 'source ~/.zshrc' to apply."
+    else
+      log_info "Zsh completion already configured in ~/.zshrc."
+    fi
+  fi
+}
+
+main() {
+  preflight_checks
+  detect_arch
+  resolve_versions
+  install_kubectl
+  create_symlink
+  configure_completion
+  log_info "All tasks completed successfully."
+}
+
+main "$@"

--- a/docs/linux/scripts/install-kubectl-kctl.sh
+++ b/docs/linux/scripts/install-kubectl-kctl.sh
@@ -3,15 +3,15 @@
 # install-kubectl-kctl.sh
 # Idempotent installer/updater for kubectl, kubecolor, and kctl (symlink) on Debian/Ubuntu systems.
 # Performs preflight checks, architecture detection, checksum validation,
-# system-wide installation, and optional shell completion setup.
+# system-wide installation via APT/dpkg, and optional shell completion setup.
 #
 
 set -euo pipefail
 
 # Default variables
 TARGET_DIR="/usr/local/bin"
-KUBECTL_BIN="${TARGET_DIR}/kubectl"
-KUBECOLOR_BIN="${TARGET_DIR}/kubecolor"
+KUBECTL_BIN="/usr/bin/kubectl"
+KUBECOLOR_BIN="/usr/bin/kubecolor"
 KCTL_LINK="${TARGET_DIR}/kctl"
 FORCE=false
 DRY_RUN=false
@@ -38,7 +38,7 @@ show_help() {
   cat << EOF
 Usage: $(basename "$0") [options]
 
-Install or update 'kubectl', 'kubecolor', and 'kctl' (symlink to kubecolor) on Debian/Ubuntu.
+Install or update 'kubectl', 'kubecolor', and 'kctl' (symlink to kubecolor) on Debian/Ubuntu via APT.
 
 Options:
   -v, --version VERSION       Install a specific kubectl version (e.g., v1.30.0) instead of latest stable.
@@ -101,7 +101,7 @@ preflight_checks() {
   fi
 
   # Check required commands
-  for cmd in curl gpg grep cut sha256sum tar; do
+  for cmd in curl gpg grep cut sha256sum dpkg apt-get; do
     if ! command -v "$cmd" >/dev/null 2>&1; then
       log_err "Required command '$cmd' is not installed. Please install it first."
       exit 1
@@ -206,44 +206,63 @@ install_kubectl() {
     return
   fi
 
+  # Extract minor version (e.g. v1.36.2 -> v1.36)
+  local version_xy
+  version_xy=$(echo "$TARGET_KUBECTL_VERSION" | grep -oE '^v[0-9]+\.[0-9]+')
+  if [[ -z "$version_xy" ]]; then
+    log_err "Failed to extract minor version from $TARGET_KUBECTL_VERSION (e.g. v1.36)"
+    exit 1
+  fi
+
   if [[ "$DRY_RUN" = "true" ]]; then
-    log_info "[DRY-RUN] Would install kubectl version $TARGET_KUBECTL_VERSION to $KUBECTL_BIN"
+    log_info "[DRY-RUN] Would setup Kubernetes APT repository for version $version_xy"
+    log_info "[DRY-RUN] Would install kubectl via apt-get"
     return
   fi
 
-  log_info "Downloading kubectl binary..."
-  local bin_url="https://dl.k8s.io/release/${TARGET_KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
-  local sha_url="${bin_url}.sha256"
+  log_info "Setting up Kubernetes APT repository for version $version_xy..."
 
-  # Download binary and checksum
-  curl -L -sS -o "${TMP_DIR}/kubectl" "$bin_url"
-  curl -L -sS -o "${TMP_DIR}/kubectl.sha256" "$sha_url"
-
-  # Validate checksum
-  log_info "Verifying SHA256 checksum for kubectl..."
-  local expected_sha
-  expected_sha=$(cat "${TMP_DIR}/kubectl.sha256")
-  local actual_sha
-  actual_sha=$(sha256sum "${TMP_DIR}/kubectl" | cut -d' ' -f1)
-
-  if [[ "$expected_sha" != "$actual_sha" ]]; then
-    log_err "kubectl checksum verification failed!"
-    log_err "Expected: $expected_sha"
-    log_err "Actual:   $actual_sha"
-    exit 1
-  fi
-  log_info "kubectl checksum verification succeeded."
-
-  # Install binary
-  log_info "Installing kubectl binary to $KUBECTL_BIN..."
-  chmod +x "${TMP_DIR}/kubectl"
+  # Ensure keyrings directory exists
   if [[ $EUID -eq 0 ]]; then
-    mv "${TMP_DIR}/kubectl" "$KUBECTL_BIN"
+    mkdir -p -m 755 /etc/apt/keyrings
   else
-    sudo mv "${TMP_DIR}/kubectl" "$KUBECTL_BIN"
-    sudo chown root:root "$KUBECTL_BIN"
+    sudo mkdir -p -m 755 /etc/apt/keyrings
   fi
-  log_info "kubectl version $(kubectl version --client | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1) installed successfully."
+
+  # Download signing key
+  local key_url="https://pkgs.k8s.io/core:/stable:/${version_xy}/deb/Release.key"
+  local keyring_file="/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
+  
+  log_info "Downloading signing key from $key_url..."
+  if [[ $EUID -eq 0 ]]; then
+    curl -fsSL "$key_url" | gpg --dearmor --yes -o "$keyring_file"
+    chmod 644 "$keyring_file"
+  else
+    curl -fsSL "$key_url" | sudo gpg --dearmor --yes -o "$keyring_file"
+    sudo chmod 644 "$keyring_file"
+  fi
+
+  # Add repository sources file
+  local repo_line="deb [signed-by=$keyring_file] https://pkgs.k8s.io/core:/stable:/${version_xy}/deb/ /"
+  local sources_file="/etc/apt/sources.list.d/kubernetes.list"
+  log_info "Adding repository line to $sources_file..."
+  if [[ $EUID -eq 0 ]]; then
+    echo "$repo_line" > "$sources_file"
+  else
+    echo "$repo_line" | sudo tee "$sources_file" > /dev/null
+  fi
+
+  # Run apt-get update and install
+  log_info "Updating package lists and installing kubectl via APT..."
+  if [[ $EUID -eq 0 ]]; then
+    apt-get update
+    apt-get install -y kubectl
+  else
+    sudo apt-get update
+    sudo apt-get install -y kubectl
+  fi
+
+  log_info "kubectl version $(kubectl version --client 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1) installed successfully via APT."
 }
 
 # 5. Perform Download and Installation of kubecolor
@@ -254,50 +273,45 @@ install_kubecolor() {
   fi
 
   if [[ "$DRY_RUN" = "true" ]]; then
-    log_info "[DRY-RUN] Would install kubecolor version $TARGET_KUBECOLOR_VERSION to $KUBECOLOR_BIN"
+    log_info "[DRY-RUN] Would download kubecolor deb package version $TARGET_KUBECOLOR_VERSION"
+    log_info "[DRY-RUN] Would install kubecolor via apt-get"
     return
   fi
 
-  log_info "Downloading kubecolor archive..."
   local kubecolor_no_v="${TARGET_KUBECOLOR_VERSION#v}"
-  local bin_url="https://github.com/kubecolor/kubecolor/releases/download/${TARGET_KUBECOLOR_VERSION}/kubecolor_${kubecolor_no_v}_linux_${ARCH}.tar.gz"
+  local deb_name="kubecolor_${kubecolor_no_v}_linux_${ARCH}.deb"
+  local bin_url="https://github.com/kubecolor/kubecolor/releases/download/${TARGET_KUBECOLOR_VERSION}/${deb_name}"
   local sha_url="https://github.com/kubecolor/kubecolor/releases/download/${TARGET_KUBECOLOR_VERSION}/checksums.txt"
 
-  # Download binary archive and checksums
-  curl -L -sS -o "${TMP_DIR}/kubecolor.tar.gz" "$bin_url"
+  log_info "Downloading kubecolor DEB package..."
+  curl -L -sS -o "${TMP_DIR}/${deb_name}" "$bin_url"
   curl -L -sS -o "${TMP_DIR}/checksums.txt" "$sha_url"
 
   # Validate checksum
-  log_info "Verifying SHA256 checksum for kubecolor..."
-  local tarball_name="kubecolor_${kubecolor_no_v}_linux_${ARCH}.tar.gz"
-  if ! grep -q "$tarball_name" "${TMP_DIR}/checksums.txt"; then
-    log_err "Tarball entry '$tarball_name' not found in checksums.txt."
+  log_info "Verifying SHA256 checksum for kubecolor DEB..."
+  if ! grep -q "$deb_name" "${TMP_DIR}/checksums.txt"; then
+    log_err "DEB package entry '$deb_name' not found in checksums.txt."
     exit 1
   fi
 
   # Extract matching line
-  grep "$tarball_name" "${TMP_DIR}/checksums.txt" > "${TMP_DIR}/kubecolor.sha256"
+  grep "$deb_name" "${TMP_DIR}/checksums.txt" > "${TMP_DIR}/kubecolor.sha256"
   
   if ! (cd "$TMP_DIR" && sha256sum --check --status kubecolor.sha256); then
-    log_err "kubecolor checksum verification failed for $tarball_name!"
+    log_err "kubecolor DEB checksum verification failed for $deb_name!"
     exit 1
   fi
-  log_info "kubecolor checksum verification succeeded."
+  log_info "kubecolor DEB checksum verification succeeded."
 
-  # Extract binary
-  log_info "Extracting kubecolor binary..."
-  tar -xzf "${TMP_DIR}/kubecolor.tar.gz" -C "$TMP_DIR" kubecolor
-
-  # Install binary
-  log_info "Installing kubecolor binary to $KUBECOLOR_BIN..."
-  chmod +x "${TMP_DIR}/kubecolor"
+  # Install package using apt-get (which handles dependencies and registers it cleanly)
+  log_info "Installing kubecolor DEB package via APT..."
   if [[ $EUID -eq 0 ]]; then
-    mv "${TMP_DIR}/kubecolor" "$KUBECOLOR_BIN"
+    apt-get install -y "${TMP_DIR}/${deb_name}"
   else
-    sudo mv "${TMP_DIR}/kubecolor" "$KUBECOLOR_BIN"
-    sudo chown root:root "$KUBECOLOR_BIN"
+    sudo apt-get install -y "${TMP_DIR}/${deb_name}"
   fi
-  log_info "kubecolor version $(kubecolor --kubecolor-version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1) installed successfully."
+
+  log_info "kubecolor version $(kubecolor --kubecolor-version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1) installed successfully via APT."
 }
 
 # 6. Create kctl symlink
@@ -322,6 +336,17 @@ create_symlink() {
       rm -f "$KCTL_LINK"
     else
       sudo rm -f "$KCTL_LINK"
+    fi
+  fi
+
+  # Create directories if they do not exist
+  local link_dir
+  link_dir=$(dirname "$KCTL_LINK")
+  if [[ ! -d "$link_dir" ]]; then
+    if [[ $EUID -eq 0 ]]; then
+      mkdir -p "$link_dir"
+    else
+      sudo mkdir -p "$link_dir"
     fi
   fi
 

--- a/src/_posts/2026-06-28-debian-ubuntu-install-kubectl-kubecolor.md
+++ b/src/_posts/2026-06-28-debian-ubuntu-install-kubectl-kubecolor.md
@@ -1,0 +1,374 @@
+---
+title: "Install kubectl and kubecolor on Debian/Ubuntu via APT"
+author: DevilDogTG
+date: 2026-06-28 15:30:00 +0700
+categories: [System Administrator, Kubernetes]
+tags: [tutorials, linux, kubernetes, kubecolor, lang:en]
+---
+
+Managing Kubernetes clusters using `kubectl` is the day-to-day norm for DevOps engineers and system administrators. However, plain text output from `kubectl` can quickly become hard to read when parsing long lists of resources or troubleshooting issues.
+
+In this guide, we will install **`kubectl`** and **`kubecolor`** (a wrapper that colorizes output for improved readability) on Debian/Ubuntu systems using native package management (`apt` / `dpkg`). We will also set up **`kctl`** as a convenient alias/symlink to `kubecolor` and configure tab auto-completion for all of them.
+
+---
+
+## Why Kubecolor?
+
+`kubecolor` is a drop-in replacement wrapper for `kubectl` that intercepts command output and adds colors in real-time. 
+
+- **Readability**: Clearly highlights statuses like `Running` (green), `Terminating` (yellow), and `CrashLoopBackOff` (red).
+- **Auto TTY Detection**: Automatically disables color styling when output is piped to files, logs, or other scripts.
+- **Paging Support**: Seamlessly integrates with tools like `less` for scrollable outputs.
+
+By symlinking `kctl` to `kubecolor`, you get a fast, colorized terminal command that keeps all standard `kubectl` arguments and autocompletions intact.
+
+---
+
+## Option 1: Automated Idempotent Installer Script
+
+Below is the complete shell script to automate the setup process. It validates your architecture (AMD64 or ARM64), downloads the GPG keys, registers the official Kubernetes APT repository, fetches the latest `kubecolor` release DEB package, verifies its SHA256 checksum, installs both packages natively via `apt`, and creates the `kctl` symlink.
+
+Create a script file (e.g. `install-kubectl-kctl.sh`), paste the following content, and make it executable:
+
+```bash
+#!/usr/bin/env bash
+# install-kubectl-kctl.sh
+# Idempotent installer/updater for kubectl, kubecolor, and kctl (symlink) on Debian/Ubuntu.
+
+set -euo pipefail
+
+TARGET_DIR="/usr/local/bin"
+KUBECTL_BIN="/usr/bin/kubectl"
+KUBECOLOR_BIN="/usr/bin/kubecolor"
+KCTL_LINK="${TARGET_DIR}/kctl"
+FORCE=false
+DRY_RUN=false
+KUBECTL_VERSION=""
+KUBECOLOR_VERSION=""
+SETUP_COMPLETION=false
+TMP_DIR=""
+
+log_info() { echo -e "\e[32m[INFO]\e[0m $*"; }
+log_warn() { echo -e "\e[33m[WARN]\e[0m $*"; }
+log_err()  { echo -e "\e[31m[ERROR]\e[0m $*" >&2; }
+
+cleanup() {
+  if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+show_help() {
+  cat << EOF
+Usage: $(basename "$0") [options]
+
+Install or update 'kubectl', 'kubecolor', and 'kctl' (symlink to kubecolor) on Debian/Ubuntu via APT.
+
+Options:
+  -v, --version VERSION       Install a specific kubectl version (e.g., v1.30.0) instead of latest stable.
+  -k, --kubecolor-version VER Install a specific kubecolor version (e.g., v0.6.0) instead of latest stable.
+  -f, --force                 Force installation/download even if already up-to-date.
+  -c, --completion            Configure shell autocompletion for kubectl, kubecolor, and kctl in ~/.bashrc and ~/.zshrc.
+  -d, --dry-run               Run preflight checks and version comparison, but do not download or install.
+  -h, --help                  Show this help message.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -v|--version) KUBECTL_VERSION="$2"; shift 2 ;;
+    -k|--kubecolor-version) KUBECOLOR_VERSION="$2"; shift 2 ;;
+    -f|--force) FORCE=true; shift ;;
+    -c|--completion) SETUP_COMPLETION=true; shift ;;
+    -d|--dry-run) DRY_RUN=true; shift ;;
+    -h|--help) show_help; exit 0 ;;
+    *) log_err "Unknown option: $1"; show_help; exit 1 ;;
+  esac
+done
+
+preflight_checks() {
+  log_info "Running preflight checks..."
+  if [[ ! -f /etc/os-release ]] || ! grep -qEi 'debian|ubuntu' /etc/os-release; then
+    log_err "This script targets Debian/Ubuntu distributions."
+    exit 1
+  fi
+
+  for cmd in curl gpg grep cut sha256sum dpkg apt-get; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      log_err "Required command '$cmd' is not installed. Please install it first."
+      exit 1
+    fi
+  done
+
+  if [[ "$DRY_RUN" = "false" ]] && [[ $EUID -ne 0 ]]; then
+    if ! command -v sudo >/dev/null 2>&1 || ! sudo -n true 2>/dev/null; then
+      log_info "Sudo privileges required. You may be prompted for your password."
+    fi
+  fi
+}
+
+detect_arch() {
+  local machine
+  machine=$(uname -m)
+  case "$machine" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    *) log_err "Unsupported architecture: $machine."; exit 1 ;;
+  esac
+  log_info "Detected architecture: $ARCH ($machine)"
+}
+
+resolve_versions() {
+  log_info "Fetching latest stable kubectl version..."
+  local latest_kubectl
+  latest_kubectl=$(curl -sSL https://dl.k8s.io/release/stable.txt)
+  TARGET_KUBECTL_VERSION="${KUBECTL_VERSION:-$latest_kubectl}"
+  [[ ! "$TARGET_KUBECTL_VERSION" =~ ^v ]] && TARGET_KUBECTL_VERSION="v${TARGET_KUBECTL_VERSION}"
+  log_info "Target kubectl version: $TARGET_KUBECTL_VERSION"
+
+  if command -v kubectl >/dev/null 2>&1; then
+    INSTALLED_KUBECTL_VERSION=$(kubectl version --client 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
+    log_info "Currently installed kubectl version: ${INSTALLED_KUBECTL_VERSION:-none}"
+  else
+    INSTALLED_KUBECTL_VERSION="none"
+  fi
+
+  log_info "Fetching latest stable kubecolor version..."
+  local redirect_url
+  redirect_url=$(curl -sSfL -o /dev/null -w "%{url_effective}" https://github.com/kubecolor/kubecolor/releases/latest || true)
+  local latest_kubecolor="v0.6.0"
+  [[ -n "$redirect_url" ]] && latest_kubecolor="${redirect_url##*/}"
+  TARGET_KUBECOLOR_VERSION="${KUBECOLOR_VERSION:-$latest_kubecolor}"
+  [[ ! "$TARGET_KUBECOLOR_VERSION" =~ ^v ]] && TARGET_KUBECOLOR_VERSION="v${TARGET_KUBECOLOR_VERSION}"
+  log_info "Target kubecolor version: $TARGET_KUBECOLOR_VERSION"
+
+  if command -v kubecolor >/dev/null 2>&1; then
+    INSTALLED_KUBECOLOR_VERSION=$(kubecolor --kubecolor-version 2>/dev/null | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
+    log_info "Currently installed kubecolor version: ${INSTALLED_KUBECOLOR_VERSION:-none}"
+  else
+    INSTALLED_KUBECOLOR_VERSION="none"
+  fi
+}
+
+install_kubectl() {
+  if [[ "$INSTALLED_KUBECTL_VERSION" == "$TARGET_KUBECTL_VERSION" ]] && [[ "$FORCE" = "false" ]]; then
+    log_info "kubectl is already at the target version ($TARGET_KUBECTL_VERSION). Skipping."
+    return
+  fi
+
+  local version_xy
+  version_xy=$(echo "$TARGET_KUBECTL_VERSION" | grep -oE '^v[0-9]+\.[0-9]+')
+
+  if [[ "$DRY_RUN" = "true" ]]; then
+    log_info "[DRY-RUN] Would setup Kubernetes APT repository for version $version_xy and install"
+    return
+  fi
+
+  log_info "Setting up Kubernetes APT repository for version $version_xy..."
+  if [[ $EUID -eq 0 ]]; then
+    mkdir -p -m 755 /etc/apt/keyrings
+    curl -fsSL "https://pkgs.k8s.io/core:/stable:/${version_xy}/deb/Release.key" | gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${version_xy}/deb/ /" > /etc/apt/sources.list.d/kubernetes.list
+    apt-get update && apt-get install -y kubectl
+  else
+    sudo mkdir -p -m 755 /etc/apt/keyrings
+    curl -fsSL "https://pkgs.k8s.io/core:/stable:/${version_xy}/deb/Release.key" | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${version_xy}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list > /dev/null
+    sudo apt-get update && sudo apt-get install -y kubectl
+  fi
+}
+
+install_kubecolor() {
+  if [[ "$INSTALLED_KUBECOLOR_VERSION" == "$TARGET_KUBECOLOR_VERSION" ]] && [[ "$FORCE" = "false" ]]; then
+    log_info "kubecolor is already at the target version ($TARGET_KUBECOLOR_VERSION). Skipping."
+    return
+  fi
+
+  if [[ "$DRY_RUN" = "true" ]]; then
+    log_info "[DRY-RUN] Would download and install kubecolor deb package version $TARGET_KUBECOLOR_VERSION"
+    return
+  fi
+
+  local kubecolor_no_v="${TARGET_KUBECOLOR_VERSION#v}"
+  local deb_name="kubecolor_${kubecolor_no_v}_linux_${ARCH}.deb"
+
+  log_info "Downloading kubecolor DEB package..."
+  curl -L -sS -o "${TMP_DIR}/${deb_name}" "https://github.com/kubecolor/kubecolor/releases/download/${TARGET_KUBECOLOR_VERSION}/${deb_name}"
+  curl -L -sS -o "${TMP_DIR}/checksums.txt" "https://github.com/kubecolor/kubecolor/releases/download/${TARGET_KUBECOLOR_VERSION}/checksums.txt"
+
+  log_info "Verifying SHA256 checksum for kubecolor..."
+  grep "$deb_name" "${TMP_DIR}/checksums.txt" > "${TMP_DIR}/kubecolor.sha256"
+  if ! (cd "$TMP_DIR" && sha256sum --check --status kubecolor.sha256); then
+    log_err "Checksum verification failed!"; exit 1
+  fi
+
+  log_info "Installing kubecolor DEB via APT..."
+  if [[ $EUID -eq 0 ]]; then
+    apt-get install -y "${TMP_DIR}/${deb_name}"
+  else
+    sudo apt-get install -y "${TMP_DIR}/${deb_name}"
+  fi
+}
+
+create_symlink() {
+  if [[ "$DRY_RUN" = "true" ]]; then
+    log_info "[DRY-RUN] Would create symlink $KCTL_LINK -> $KUBECOLOR_BIN"
+    return
+  fi
+
+  log_info "Ensuring 'kctl' symlink points to 'kubecolor'..."
+  local link_dir=$(dirname "$KCTL_LINK")
+  [[ ! -d "$link_dir" ]] && ( [[ $EUID -eq 0 ]] && mkdir -p "$link_dir" || sudo mkdir -p "$link_dir" )
+
+  if [[ $EUID -eq 0 ]]; then
+    ln -sf "$KUBECOLOR_BIN" "$KCTL_LINK"
+  else
+    sudo ln -sf "$KUBECOLOR_BIN" "$KCTL_LINK"
+  fi
+}
+
+configure_completion() {
+  if [[ "$SETUP_COMPLETION" = "false" ]]; then return; fi
+  if [[ "$DRY_RUN" = "true" ]]; then return; fi
+
+  local line="source <(kubectl completion \${SHELL##*/})"
+  
+  # Setup Bash completion
+  if [[ -f "$HOME/.bashrc" ]] && ! grep -q "kubectl completion bash" "$HOME/.bashrc"; then
+    cat << 'EOF' >> "$HOME/.bashrc"
+if command -v kubectl >/dev/null 2>&1; then
+  source <(kubectl completion bash)
+  complete -o default -F __start_kubectl kubecolor 2>/dev/null || true
+  complete -o default -F __start_kubectl kctl 2>/dev/null || true
+fi
+EOF
+  fi
+
+  # Setup Zsh completion
+  if [[ -f "$HOME/.zshrc" ]] && ! grep -q "kubectl completion zsh" "$HOME/.zshrc"; then
+    cat << 'EOF' >> "$HOME/.zshrc"
+if command -v kubectl >/dev/null 2>&1; then
+  source <(kubectl completion zsh)
+  compdef __start_kubectl kubecolor 2>/dev/null || true
+  compdef __start_kubectl kctl 2>/dev/null || true
+fi
+EOF
+  fi
+}
+
+main() {
+  preflight_checks
+  detect_arch
+  resolve_versions
+  if [[ "$DRY_RUN" = "false" ]]; then TMP_DIR=$(mktemp -d); fi
+  install_kubectl
+  install_kubecolor
+  create_symlink
+  configure_completion
+  log_info "Finished successfully."
+}
+
+main "$@"
+```
+
+To execute the script and configure tab completion automatically for your active shells, run:
+```bash
+bash install-kubectl-kctl.sh --completion
+```
+
+---
+
+## Option 2: Step-by-Step Manual Installation
+
+If you prefer to perform the configuration steps manually, follow the process outlined below.
+
+### Step 1: Install kubectl via Official APT Repository
+
+First, download the official signing key and register the repository for the Kubernetes package pool.
+
+```bash
+# Create the keyrings folder if it does not exist
+sudo mkdir -p -m 755 /etc/apt/keyrings
+
+# Download the key (e.g. for Kubernetes version 1.36)
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.36/deb/Release.key | sudo gpg --dearmor --yes -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+sudo chmod 644 /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+# Register the APT source repository
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.36/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+# Update package lists and install kubectl
+sudo apt-get update
+sudo apt-get install -y kubectl
+```
+
+### Step 2: Download and Install kubecolor DEB Package
+
+Download the appropriate `.deb` package for your CPU architecture from the official GitHub Release page.
+
+```bash
+# Fetch latest version (e.g., v0.6.0)
+VERSION="v0.6.0"
+VERSION_NO_V="0.6.0"
+ARCH=$(dpkg --print-architecture) # amd64 or arm64
+
+# Download the DEB package
+wget https://github.com/kubecolor/kubecolor/releases/download/${VERSION}/kubecolor_${VERSION_NO_V}_linux_${ARCH}.deb
+
+# Install the package via apt (which manages standard system registration)
+sudo apt-get install -y ./kubecolor_${VERSION_NO_V}_linux_${ARCH}.deb
+
+# Clean up
+rm kubecolor_${VERSION_NO_V}_linux_${ARCH}.deb
+```
+
+### Step 3: Create the `kctl` Command Symlink
+
+Create a symbolic link in `/usr/local/bin` pointing to `/usr/bin/kubecolor`. This provides a global, shorter alias without polluting `/usr/bin`.
+
+```bash
+sudo ln -sf /usr/bin/kubecolor /usr/local/bin/kctl
+```
+
+---
+
+## Configure Shell Autocompletion
+
+`kubecolor` operates as a wrapper around the `kubectl` CLI. Therefore, you must configure the standard `kubectl` autocompletion and then instruct the shell to reuse that completion function (`__start_kubectl`) for `kubecolor` and `kctl`.
+
+### Bash Setup
+Append the following lines to your `~/.bashrc` file:
+
+```bash
+# Kubernetes and Kubecolor completion
+if command -v kubectl >/dev/null 2>&1; then
+  source <(kubectl completion bash)
+  complete -o default -F __start_kubectl kubecolor 2>/dev/null || true
+  complete -o default -F __start_kubectl kctl 2>/dev/null || true
+fi
+```
+Then reload your configuration:
+```bash
+source ~/.bashrc
+```
+
+### Zsh Setup
+Append the following lines to your `~/.zshrc` file:
+
+```bash
+# Kubernetes and Kubecolor completion
+if command -v kubectl >/dev/null 2>&1; then
+  source <(kubectl completion zsh)
+  compdef __start_kubectl kubecolor 2>/dev/null || true
+  compdef __start_kubectl kctl 2>/dev/null || true
+fi
+```
+Then reload your configuration:
+```bash
+source ~/.zshrc
+```
+
+Now, try running `kctl get p[TAB]` and watch the resource name autocomplete while rendering in beautiful, colorized terminal styles!


### PR DESCRIPTION
## What changed
Added a repeatable installer script, guide, and blog post for setting up `kubectl` and `kubecolor` on Debian/Ubuntu systems using `apt` and `.deb` packaging:
- **`docs/linux/scripts/install-kubectl-kctl.sh`**: Installs `kubectl` via the official Kubernetes repository and `kubecolor` via the official release DEB package (verifying its SHA256 checksum). Creates a `kctl` symlink pointing to `kubecolor` for colorized output. Sets up tab completion for all commands.
- **`docs/linux/install-kubectl-kctl.md`**: Guide explaining the installer script and manual step-by-step setup.
- **`src/_posts/2026-06-28-debian-ubuntu-install-kubectl-kubecolor.md`**: Blog post promoting the setup guide.
- Linked the guide in the Linux index and tracked it in agent-brains plan and memory structures.

## Why
Make the setup and update of `kubectl` and `kubecolor` fully repeatable, utilizing the native `apt` package manager for clean dependency tracking and system integration, and alias `kubecolor` as `kctl` for faster typing.

## Breaking changes
none