### PR TITLE
fix(winget): fix claude command not recognized path issue

### DIFF
--- a/.agent-brains/handover/2026-07-10.md
+++ b/.agent-brains/handover/2026-07-10.md
@@ -1,0 +1,23 @@
+## Session Handover — 2026-07-10
+
+### Accomplished
+- **Diagnosed and resolved WinGet path issue:** WinGet failed to create a command alias for `claude` (installed as a portable package) under `%LOCALAPPDATA%\Microsoft\WinGet\Links` due to lack of admin/Developer Mode privileges.
+- **Created manual shims:** Created `claude.cmd` (for Command Prompt/PowerShell) and `claude` (shell script for Bash/Unix-like shells) in the WinGet Links directory.
+- **Added troubleshooting guide:** Documented the problem, root cause, and shim solution in `docs/troubleshooting/winget-claude-path-issue.md` and registered it in its `Index.md`.
+- **Fixed brains-index.ps1 syntax error:** Replaced a multi-byte em-dash character `—` with an ASCII hyphen `-` in the global `brains-index.ps1` script to prevent encoding/syntax errors.
+- **Completed Plan:** Opened, logged, and finalized the `winget-claude-path` task.
+
+### Current State
+- Active plan: None (all completed).
+- Branch: `bugfix/winget-claude-path` (committed).
+- Pull Request: Created draft PR #37 and marked it ready for review.
+
+### Next Steps
+1. Wait for GitHub Actions checks to pass on PR #37.
+2. Merge the Pull Request and prune the local branch.
+
+### Decisions Made
+- None.
+
+### Blockers / Notes
+- None.

--- a/.agent-brains/memory/changes/2026-07-10-winget-claude-path.md
+++ b/.agent-brains/memory/changes/2026-07-10-winget-claude-path.md
@@ -1,0 +1,6 @@
+---
+date: 2026-07-10
+title: Fix winget-installed claude not recognized path issue
+---
+
+Identified that WinGet installs `Anthropic.ClaudeCode` as a portable package but fails to create shims in `C:\Users\devildogtg\AppData\Local\Microsoft\WinGet\Links` due to lack of admin/Developer Mode privileges. Created manual shims `claude.cmd` and `claude` (shell script) in the links directory. Documented the issue and fix in `docs/troubleshooting/winget-claude-path-issue.md`.

--- a/.agent-brains/memory/overview.md
+++ b/.agent-brains/memory/overview.md
@@ -4,22 +4,25 @@ Initial status.
 
 ## Recent Changes
 <!-- begin:changes -->
-### 2026-06-28 — Add kubectl and kctl installation script and guide
-Created an idempotent install and update script for `kubectl` and `kctl` on Debian/Ubuntu systems, featuring preflight checks, architecture detection, checksum validation, and automated shell auto-completion. Added a corresponding documentation guide under `docs/linux/install-kubectl-kctl.md` and linked it in the Linux topic index.
+### 2026-07-10 - Fix winget-installed claude not recognized path issue
+Identified that WinGet installs `Anthropic.ClaudeCode` as a portable package but fails to create shims in `C:\Users\devildogtg\AppData\Local\Microsoft\WinGet\Links` due to lack of admin/Developer Mode privileges. Created manual shims `claude.cmd` and `claude` (shell script) in the links directory. Documented the issue and fix in `docs/troubleshooting/winget-claude-path-issue.md`.
 
-### 2026-06-28 — Modernize CI/CD workflows and fix deploy syntax
+### 2026-06-28 - Modernize CI/CD workflows and fix deploy syntax
 Modernized the personal knowledge base workflows to target `main` as the sole primary branch. Fixed syntax errors in double-hyphen flags within `.github/workflows/pages-deploy.yml`.
 
-### 2026-06-28 — Restructure into dual-purpose workspace (/docs + /src)
+### 2026-06-28 - Add kubectl and kctl installation script and guide
+Created an idempotent install and update script for `kubectl` and `kctl` on Debian/Ubuntu systems, featuring preflight checks, architecture detection, checksum validation, and automated shell auto-completion. Added a corresponding documentation guide under `docs/linux/install-kubectl-kctl.md` and linked it in the Linux topic index.
+
+### 2026-06-28 - Restructure into dual-purpose workspace (/docs + /src)
 Restructured the repo into a dual-purpose workspace:
-- `/docs` — local knowledge base of rough notes, organized into topic folders each with an
+- `/docs` â€” local knowledge base of rough notes, organized into topic folders each with an
   `Index.md` (seeded by copying 7 notes from `../help-desk`; originals left as backup).
-- `/src` — the relocated Jekyll/Chirpy web blog (moved from repo root via `git mv`).
+- `/src` â€” the relocated Jekyll/Chirpy web blog (moved from repo root via `git mv`).
 
 Rewired both GitHub Pages workflows (`pages-build.yml`, `pages-deploy.yml`) to build from
 `/src` using `defaults.run.working-directory: src` + `working-directory: src` on Ruby setup,
 artifact `path: src/_site...`, and added `docs/**` to `paths-ignore`. Updated `.gitmodules`
-submodule path to `src/assets/lib` (submodule is unused — theme comes from the
+submodule path to `src/assets/lib` (submodule is unused â€” theme comes from the
 `jekyll-theme-chirpy` gem). Deleted the already-migrated `Backup/` folder. Validated locally:
 `bundle install` + production `jekyll build` (45 posts, CNAME preserved) + htmlproofer passed
 with 0 errors.
@@ -29,5 +32,5 @@ non-strict; `/src` may also hold original posts).
 <!-- end:changes -->
 
 ## Key Decisions
-- [ADR-0001](../decisions/ADR-0001-relocate-blog-into-src.md) — relocate the Jekyll blog into
+- [ADR-0001](../decisions/ADR-0001-relocate-blog-into-src.md) â€” relocate the Jekyll blog into
   `/src` and build GitHub Pages from there, with `/docs` as the local knowledge base.

--- a/.agent-brains/plan/INDEX.md
+++ b/.agent-brains/plan/INDEX.md
@@ -3,6 +3,7 @@
 
 | Plan | Status | Progress | Branch | Updated |
 |------|--------|----------|--------|---------|
-| [modernize-workflow](modernize-workflow/master-plan.md) | done | 100% | feat/modernize-workflow | 2026-06-28 |
-| [dual-purpose-workspace](archive/dual-purpose-workspace/master-plan.md) | done | 100% | feat/dual-purpose-workspace | 2026-06-28 |
 | [install-kubectl-kctl](install-kubectl-kctl/master-plan.md) | done | 100% | feature/install-kubectl-kctl | 2026-06-28 |
+| [modernize-workflow](modernize-workflow/master-plan.md) | done | 100% | feat/modernize-workflow | 2026-06-28 |
+| [windows-startup-errors](windows-startup-errors/master-plan.md) | active | 0% | bugfix/windows-startup-errors | 2026-06-29 |
+| [winget-claude-path](winget-claude-path/master-plan.md) | done | 100% | bugfix/winget-claude-path | 2026-07-10 |

--- a/.agent-brains/plan/backlog.md
+++ b/.agent-brains/plan/backlog.md
@@ -1,19 +1,6 @@
-<!-- generated: do not edit — run scripts/brains-index (.ps1|.sh). Source: plan/*.md frontmatter. See ADR-0002. -->
-# Project Roadmap
+<!-- agent-maintained: do not edit manually -->
+# Backlog
 
-_Generated 2026-06-29 from `plan/*.md` frontmatter. Edit the per-task plan files, not this file._
-
-## Active
-- [ ] [Plan Index](INDEX.md)
-
-## Blocked
-_None._
-
-## Deferred
-_None._
-
-## Done
-_None._
-
-## Archived
-_None._
+| Plan | Status | Progress | Branch | Updated |
+|------|--------|----------|--------|---------|
+| [windows-startup-errors](windows-startup-errors/master-plan.md) | active | 0% | bugfix/windows-startup-errors | 2026-06-29 |

--- a/.agent-brains/plan/winget-claude-path/master-plan.md
+++ b/.agent-brains/plan/winget-claude-path/master-plan.md
@@ -1,0 +1,21 @@
+---
+task: winget-claude-path
+status: done
+progress: 100
+branch: bugfix/winget-claude-path
+created: 2026-07-10
+updated: 2026-07-10
+---
+
+# Plan: Fix winget-installed 'claude' Not Recognized
+
+## Goal
+Diagnose why `claude` (installed via winget) is not recognized as a command, verify the PATH configuration, resolve it, and document the solution in the knowledge base.
+
+## Checklist
+- [x] Research/Diagnose: Check winget package installation status and location.
+- [x] Check if the WinGet shims/links directory (e.g., `AppData\Local\Microsoft\WinGet\Links`) contains the `claude` shim.
+- [x] Check if the WinGet Links directory is in the PATH environment variable.
+- [x] Implement Fix: Add WinGet Links directory to the PATH if missing, or recreate the shim.
+- [x] Verify: Test calling `claude` in a fresh terminal session.
+- [x] Document: Add a troubleshooting entry to `docs/troubleshooting/` and update its `Index.md`.

--- a/docs/troubleshooting/Index.md
+++ b/docs/troubleshooting/Index.md
@@ -4,3 +4,4 @@ Diagnostics, root-cause investigations, and fixes.
 
 ## Notes
 - [Troubleshooting RDP Connection Issues on Ubuntu (gnome-remote-desktop)](remote_desktop_troubleshooting.md)
+- [WinGet Claude Code Command Not Found](winget-claude-path-issue.md)

--- a/docs/troubleshooting/winget-claude-path-issue.md
+++ b/docs/troubleshooting/winget-claude-path-issue.md
@@ -1,0 +1,36 @@
+# WinGet Claude Code Command Not Found
+
+## Problem
+After installing Claude Code (`Anthropic.ClaudeCode`) via WinGet, trying to call `claude` in the terminal results in:
+```
+claude: The term 'claude' is not recognized as a name of a cmdlet, function, script file, or executable program.
+```
+Even after restarting the terminal, the command remains unrecognized.
+
+## Root Cause
+WinGet installs `Anthropic.ClaudeCode` as a **portable** package in:
+`%LOCALAPPDATA%\Microsoft\WinGet\Packages\Anthropic.ClaudeCode_Microsoft.Winget.Source_8wekyb3d8bbwe\claude.exe`
+
+By default, WinGet creates command-line aliases (symbolic links or shims) in:
+`%LOCALAPPDATA%\Microsoft\WinGet\Links`
+
+However, creating symbolic links on Windows requires either administrator privileges or Developer Mode enabled. When installing as a non-admin, WinGet silently fails to create the link/shortcut for the `claude.exe` binary in the `Links` folder, meaning it cannot be resolved even though the `Links` folder itself is in the user's `PATH`.
+
+## Solution
+Create manual shims in the `%LOCALAPPDATA%\Microsoft\WinGet\Links` directory so they resolve within the existing PATH.
+
+### 1. Windows Command Prompt & PowerShell (`claude.cmd`)
+Create a file at `%LOCALAPPDATA%\Microsoft\WinGet\Links\claude.cmd` containing:
+```cmd
+@echo off
+"C:\Users\devildogtg\AppData\Local\Microsoft\WinGet\Packages\Anthropic.ClaudeCode_Microsoft.Winget.Source_8wekyb3d8bbwe\claude.exe" %*
+```
+
+### 2. Git Bash & WSL (`claude` shell script)
+Create a file at `%LOCALAPPDATA%\Microsoft\WinGet\Links\claude` (no extension) containing:
+```bash
+#!/bin/sh
+exec "C:/Users/devildogtg/AppData/Local/Microsoft/WinGet/Packages/Anthropic.ClaudeCode_Microsoft.Winget.Source_8wekyb3d8bbwe/claude.exe" "$@"
+```
+
+Once these shims are placed in the links folder, the `claude` command will work in any terminal session.


### PR DESCRIPTION
## What changed
Fixed an issue where the `claude` CLI (Anthropic.ClaudeCode) installed via WinGet is not recognized by the terminal. Added manual command-line shims (`claude.cmd` for CMD/PowerShell and `claude` for Bash/Unix-like shells) into the WinGet Links directory (`%LOCALAPPDATA%\Microsoft\WinGet\Links`). Also documented the issue and solution in `docs/troubleshooting/winget-claude-path-issue.md`.

## Why
WinGet installs the `Anthropic.ClaudeCode` package as a portable tool but fails to create shims under the user links folder due to lacking Administrator privileges or Developer Mode. Creating the shims manually resolves the path problem within the user's existing environment.

## Breaking changes
None
